### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install required tools (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libz3-4 libz3-dev crossbuild-essential-riscv64
+        run: sudo apt-get install libz3-4 libz3-dev crossbuild-essential-riscv64 qemu-user-static
 
       - name: Fetch commits so that Iceberg doesn't crash
         run: git fetch --unshallow

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,11 @@ jobs:
 
       - name: Install required tools (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libz3-4 libz3-dev crossbuild-essential-riscv64 qemu-user-static
+        run: |
+          sudo apt-get install libz3-4 libz3-dev crossbuild-essential-riscv64 qemu-user-static gdb-multiarch
+          # Following is needed because by default, libgdbs uses /usr/bin/gdb
+          # which is not multiarch GDB! Nasty workaround, indeed.
+          sudo cp /usr/bin/gdb-multiarch /usr/bin/gdb
 
       - name: Fetch commits so that Iceberg doesn't crash
         run: git fetch --unshallow

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ stx/*.s
 opcodesgen/opcodes.m4
 opcodesgen/opcodes.st
 
+# test shell by-products
+shell.o
+shell-*
+
 # git merge by-products
 *.orig
 

--- a/3rdparty.gmk
+++ b/3rdparty.gmk
@@ -24,6 +24,24 @@ $(ARCHC_PDL_DIR): $(ARCHC_DIR)
 	(cd $(ARCHC_DIR) && ./get-pdls.sh)
 endif
 
+ifndef LIBGDBS_DIR
+LIBGDBS_DIR  = ../3rdparty/jv/libgdbs
+LIBGDBS_URL ?= https://swing.fit.cvut.cz/hg/jv-libgdbs
+
+$(LIBGDBS_DIR):
+	mkdir -p $(shell dirname $@)
+	hg clone $(LIBGDBS_URL) $@
+endif
+
+ifndef VDB_DIR
+VDB_DIR  = ../3rdparty/jv/vdb
+VDB_URL ?= https://swing.fit.cvut.cz/hg/jv-vdb
+
+$(VDB_DIR):
+	mkdir -p $(shell dirname $@)
+	hg clone $(VDB_URL) $@
+endif
+
 GNUmakefile.local::
 	@echo "# Dependecy tunables. There's no need to change anything," >> $@
 	@echo "# suitable defaults are provided." >> $@
@@ -43,3 +61,10 @@ GNUmakefile.local::
 	@echo "# it will be fetched by 'get-pdls.sh' script." >> $@
 	@echo "# ARCHC_PDL_DIR=$$\(ARCHC_DIR\)/pdl" >> $@
 	@echo "" >> $@
+	@echo "# To load libgdbs from local directory, set LIBGDBS_DIR" >> $@
+	@echo "# variable to directory where libgdbs is cloned. If unset (default)" >> $@
+	@echo "# it will be fetched from upstream repository." >> $@
+	@echo "# " >> $@
+	@echo "# NOTE: libgdbs is only used/required when using Smalltalk/X!" >> $@
+	@echo "# " >> $@
+	@echo "# LIBGDBS_DIR=$$(shell realpath $$(dir $$(STX))/../../../jv/libgdbs)" >> $@

--- a/pharo/GNUmakefile
+++ b/pharo/GNUmakefile
@@ -11,7 +11,7 @@ PHARO_VERSION ?= 80
 include ../3rdparty.gmk
 include ../pharo.gmk
 
-build: $(PROJECT).image
+build: $(PROJECT).image shells
 	@echo ""
 	@echo "To open Pharo $(PROJECT) image run:"
 	@echo ""
@@ -37,10 +37,13 @@ test: build
 	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(PHARO_VM_HEADLESS) $(PROJECT).image test --fail-on-failure \
 		"$(PROJECT)"
 
+shells:
+	make -C ../shell
+
 clean::
 	rm -f $(PROJECT).image $(PROJECT).changes *Test.xml *.fuel
 	rm -fr pharo-local
 
 mrproper:: clean
 
-.PHONY: all build run test clean mrproper
+.PHONY: all build run test shells clean mrproper

--- a/pharo/GNUmakefile
+++ b/pharo/GNUmakefile
@@ -12,6 +12,11 @@ include ../3rdparty.gmk
 include ../pharo.gmk
 
 build: $(PROJECT).image
+	@echo ""
+	@echo "To open Pharo $(PROJECT) image run:"
+	@echo ""
+	@echo "    make run"
+	@echo ""
 
 $(PROJECT).image: $(PHARO_VM) $(PHARO_IMAGE) ../src/*/*.st $(MACHINEARITHMETIC_DIR) $(ARCHC_DIR) $(ARCHC_PDL_DIR)
 	$(PHARO_VM_HEADLESS) $(PHARO_IMAGE) save $(shell pwd)/$(PROJECT)
@@ -24,17 +29,12 @@ $(PROJECT).image: $(PHARO_VM) $(PHARO_IMAGE) ../src/*/*.st $(MACHINEARITHMETIC_D
 	# Load Tinyrossa
 	$(PHARO_VM_HEADLESS) $@ eval --save "(IceRepositoryCreator new location: '..' asFileReference; createRepository) register" || rm $@
 	$(PHARO_VM_HEADLESS) $@ eval --save "Metacello new baseline: '$(PROJECT)'; repository: 'tonel://../src'; onConflictUseLoaded; load." || rm $@
-	@echo ""
-	@echo "To open Pharo $(PROJECT) image run:"
-	@echo ""
-	@echo "    ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(PHARO_VM) $(PROJECT).image"
-	@echo ""
 
-run: $(PROJECT).image $(PHARO_VM)
-	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(PHARO_VM) $<
+run: build
+	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(PHARO_VM) $(PROJECT).image
 
-test: $(PROJECT).image $(PHARO_VM)
-	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(PHARO_VM_HEADLESS) $< test --fail-on-failure \
+test: build
+	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(PHARO_VM_HEADLESS) $(PROJECT).image test --fail-on-failure \
 		"$(PROJECT)"
 
 clean::
@@ -42,3 +42,5 @@ clean::
 	rm -fr pharo-local
 
 mrproper:: clean
+
+.PHONY: all build run test clean mrproper

--- a/shell/GNUmakefile
+++ b/shell/GNUmakefile
@@ -1,0 +1,24 @@
+ifndef ARCH
+
+all:
+	$(MAKE) ARCH=riscv64
+	$(MAKE) ARCH=x86_64
+
+else
+
+# Cross-compiler toolchain prefix
+CROSS?=$(ARCH)-linux-gnu-
+
+all: shell-$(ARCH)
+
+shell-$(ARCH): shell.c shell.link
+	$(CROSS)gcc -ggdb2 -O2 -static -T shell.link -o $@ $<
+
+endif
+
+clean:
+	rm -f shell-*
+
+
+
+

--- a/shell/shell.c
+++ b/shell/shell.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#define NZONE_SIZE 512
+
+__asm__(
+	"                                  \n"
+	".section .nzone,\"awx\", @progbits\n"
+	"nzone:                            \n"
+	".space " TOSTRING(NZONE_SIZE) "   \n"
+	"                                  \n"
+	".section .text                    \n"
+);
+
+extern unsigned char nzone[NZONE_SIZE];
+
+typedef int (*entry_func)();
+static entry_func entry = (entry_func)(&nzone);
+
+int main() {
+	return entry();
+}

--- a/shell/shell.link
+++ b/shell/shell.link
@@ -1,0 +1,6 @@
+SECTIONS
+{
+  .nzone 0x00080000 : {  }
+}
+INSERT AFTER .text;
+

--- a/src/BaselineOfTinyrossa/ManifestBaselineOfTinyrossa.class.st
+++ b/src/BaselineOfTinyrossa/ManifestBaselineOfTinyrossa.class.st
@@ -16,10 +16,11 @@ ManifestBaselineOfTinyrossa class >> includedInPreRequisites [
 	included := #(
 		#'BaselineOfArchC'
 		#'Tinyrossa'
-		#'Tinyrossa-Tests'
 		#'Tinyrossa-RISCV'
+		#'Tinyrossa-Tests'
+		#'Tinyrossa-Tests-RISCV'
 	).
-
+	
 	(Smalltalk getPackageDirectoryForPackage:#'jv:vdb') notNil ifTrue:[
 		included := included copyWith: #'Tinyrossa-Tools-SmalltalkX'
 	].

--- a/src/BaselineOfTinyrossa/ManifestBaselineOfTinyrossa.class.st
+++ b/src/BaselineOfTinyrossa/ManifestBaselineOfTinyrossa.class.st
@@ -11,13 +11,20 @@ ManifestBaselineOfTinyrossa class >> includedInPreRequisites [
 	 Redefine this, if classes from other packages are referred to via reflection
 	 or by constructing names dynamically (i.e. the search cannot find it)"
 
-	^ #(
+	| included |
+
+	included := #(
 		#'BaselineOfArchC'
 		#'Tinyrossa'
 		#'Tinyrossa-Tests'
 		#'Tinyrossa-RISCV'
-		#'Tinyrossa-Tools-SmalltalkX'
-	)
+	).
+
+	(Smalltalk getPackageDirectoryForPackage:#'jv:vdb') notNil ifTrue:[
+		included := included copyWith: #'Tinyrossa-Tools-SmalltalkX'
+	].
+
+	^included
 ]
 
 { #category : #'stx - description' }

--- a/src/Tinyrossa-Tests-RISCV/TRRV64GCompilationTests.class.st
+++ b/src/Tinyrossa-Tests-RISCV/TRRV64GCompilationTests.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #TRRV64GCompilationTests,
+	#superclass : #TRCompilationTestCase,
+	#category : #'Tinyrossa-Tests-RISCV'
+}
+
+{ #category : #running }
+TRRV64GCompilationTests >> setUp [
+	self setUpForTarget: TRRV64GLinux default
+]
+
+{ #category : #'tests - examples' }
+TRRV64GCompilationTests >> test_example01_meaningOfLife [
+	| debugger |
+
+	TRCompilationExamples new
+		compilation: compilation;
+		example01_meaningOfLife.
+
+	debugger := shell debugger.
+	debugger memoryAt: shell nzone put: compilation codeBuffer bytes.
+	debugger c.
+	self assert: (debugger getRegister: 'a0') equals: 42.
+]
+
+{ #category : #'tests - examples' }
+TRRV64GCompilationTests >> test_example04_factorial_i [
+	| debugger |
+
+	TRCompilationExamples new
+		compilation: compilation;
+		example04_factorial_i.
+
+	debugger := shell debugger.
+	debugger memoryAt: shell nzone put: compilation codeBuffer bytes.
+	debugger setRegister: 'a0' to: 5.
+	debugger c.
+	self assert: (debugger getRegister: 'a0') equals: 5 factorial.
+]
+
+{ #category : #'tests - examples' }
+TRRV64GCompilationTests >> test_example05_factorial_r [
+	| debugger |
+
+	TRCompilationExamples new
+		compilation: compilation;
+		example05_factorial_r.
+
+	debugger := shell debugger.
+	debugger memoryAt: shell nzone put: compilation codeBuffer bytes.
+	debugger setRegister: 'a0' to: 5.
+	debugger c.
+	self assert: (debugger getRegister: 'a0') equals: 5 factorial.
+]

--- a/src/Tinyrossa-Tests-RISCV/TRRV64GLinux.extension.st
+++ b/src/Tinyrossa-Tests-RISCV/TRRV64GLinux.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #TRRV64GLinux }
+
+{ #category : #'*Tinyrossa-Tests-RISCV' }
+TRRV64GLinux >> qemu [
+	^ 'qemu-riscv64-static'
+]

--- a/src/Tinyrossa-Tests-RISCV/package.st
+++ b/src/Tinyrossa-Tests-RISCV/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Tinyrossa-Tests-RISCV' }

--- a/src/Tinyrossa-Tests/ManifestTinyrossaTests.class.st
+++ b/src/Tinyrossa-Tests/ManifestTinyrossaTests.class.st
@@ -1,0 +1,40 @@
+Class {
+	#name : #ManifestTinyrossaTests,
+	#superclass : #PackageManifest,
+	#category : #'Tinyrossa-Tests-Manifest'
+}
+
+{ #category : #'stx - description' }
+ManifestTinyrossaTests class >> mandatoryPreRequisites [
+	"list packages which are mandatory as a prerequisite.
+	 This are packages containing superclasses of my classes and classes which
+	 are extended by myself.
+	 They are mandatory, because we need these packages as a prerequisite for loading and compiling.
+	 This method is generated automatically,
+	 by searching along the inheritance chain of all of my classes.
+	 Please take a look at the #referencedPreRequisites method as well."
+
+	^ #(
+		#Tinyrossa    "TRCompilationExamples - superclass of TRCompilationExamplesTests"
+		#'stx:goodies/sunit'    "TestAsserter - superclass of TRCompilationExamplesTests"
+		#'stx:libbasic'    "Object - superclass of ManifestTinyrossaTests"
+		#'stx:libcompat'    "PackageManifest - superclass of ManifestTinyrossaTests"
+	)
+]
+
+{ #category : #'stx - description' }
+ManifestTinyrossaTests class >> referencedPreRequisites [
+	"list packages which are a prerequisite, because they contain
+	 classes which are referenced by my classes.
+	 These packages are NOT needed as a prerequisite for compiling or loading,
+	 however, a class from it may be referenced during execution and having it
+	 unloaded then may lead to a runtime doesNotUnderstand error, unless the caller
+	 includes explicit checks for the package being present.
+	 This method is generated automatically,
+	 by searching all classes (and their packages) which are referenced by my classes.
+	 Please also take a look at the #mandatoryPreRequisites method"
+
+	^ #(
+		#'jv:libgdbs'
+	)
+]

--- a/src/Tinyrossa-Tests/TRCompilationExamples.extension.st
+++ b/src/Tinyrossa-Tests/TRCompilationExamples.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #TRCompilationExamples }
+
+{ #category : #'*Tinyrossa-Tests' }
+TRCompilationExamples >> compilation:aTRCompilation [
+	compilation := aTRCompilation.
+]

--- a/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #TRCompilationTestCase,
+	#superclass : #TestCase,
+	#instVars : [
+		'compilation',
+		'shell'
+	],
+	#category : #'Tinyrossa-Tests'
+}
+
+{ #category : #running }
+TRCompilationTestCase >> setUpForTarget: aTRCompilationTarget [
+	compilation := TRCompilation forTarget: aTRCompilationTarget.
+	shell := TRCompilationTestShell forTarget: aTRCompilationTarget.
+]
+
+{ #category : #running }
+TRCompilationTestCase >> tearDown [
+	super tearDown.
+	shell notNil ifTrue: [ 
+		shell tearDown.
+		shell := nil.
+	].
+]

--- a/src/Tinyrossa-Tests/TRCompilationTestShell.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestShell.class.st
@@ -1,0 +1,78 @@
+Class {
+	#name : #TRCompilationTestShell,
+	#superclass : #TestAsserter,
+	#instVars : [
+		'target',
+		'binary',
+		'debugger'
+	],
+	#classVars : [
+		'DefaultImpl'
+	],
+	#category : #'Tinyrossa-Tests-Shells-SmalltalkX'
+}
+
+{ #category : #accessing }
+TRCompilationTestShell class >> defaultImpl [
+	DefaultImpl isNil ifTrue: [ ^ TRCompilationTestShellQEMU ].
+	^ DefaultImpl
+]
+
+{ #category : #'instance creation' }
+TRCompilationTestShell class >> forTarget: aTRCompilationTarget [
+	self == TRCompilationTestShell ifTrue: [ 
+		^ self defaultImpl forTarget: aTRCompilationTarget
+	] ifFalse: [ 
+		^ self new initializeWithTarget: aTRCompilationTarget
+	].
+]
+
+{ #category : #accessing }
+TRCompilationTestShell >> debugger [
+	self assert: debugger notNil.
+	^ debugger
+]
+
+{ #category : #initialization }
+TRCompilationTestShell >> initializeWithTarget: aTRCompilationTarget [
+	target := aTRCompilationTarget.
+	self setUp; reset.
+]
+
+{ #category : #accessing }
+TRCompilationTestShell >> nzone [
+	"Return the address of nzone. See shell.link linker script."
+
+	^ 16r00080000
+]
+
+{ #category : #running }
+TRCompilationTestShell >> reset [
+	self debugger setRegister: 'pc' to: self nzone
+]
+
+{ #category : #running }
+TRCompilationTestShell >> setUp [
+	| path |
+
+	path := (Smalltalk getPackageDirectoryForPackage: self class package).
+	self assert: path notNil.
+	path := path / '..' / '..' / 'shell'.
+	self assert: path isDirectory.
+
+	binary := path / ('shell-' , (target name upTo: $-)).
+	self assert: binary isExecutable.
+]
+
+{ #category : #running }
+TRCompilationTestShell >> tearDown [
+	(debugger notNil and: [ debugger isConnected ]) ifTrue: [
+		 debugger send: 'kill'.
+		 (Smalltalk includesKey: #VDBDebuggerApplication) ifTrue: [ 
+			 ((Smalltalk at: #VDBDebuggerApplication) allInstances allSatisfy:[:vdbApp | vdbApp debugger ~~ target]) ifTrue: [ 
+				 debugger send: 'quit' andWait: false.
+			 ].
+		 ].
+	 ].
+	 debugger := nil.
+]

--- a/src/Tinyrossa-Tests/TRCompilationTestShellGem5.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestShellGem5.class.st
@@ -1,0 +1,56 @@
+Class {
+	#name : #TRCompilationTestShellGem5,
+	#superclass : #TRCompilationTestShell,
+	#instVars : [
+		'gem5'
+	],
+	#classVars : [
+		'Host'
+	],
+	#category : #'Tinyrossa-Tests-Shells-SmalltalkX'
+}
+
+{ #category : #accessing }
+TRCompilationTestShellGem5 class >> host [
+	^ Host isNil ifTrue: [ 'unleashed' ] ifFalse: [ Host ]
+]
+
+{ #category : #accessing }
+TRCompilationTestShellGem5 class >> host: aString [
+	Host := aString
+]
+
+{ #category : #running }
+TRCompilationTestShellGem5 >> setUp [
+	| gem5cmd |
+
+	super setUp.
+
+	self assert: (OperatingSystem getEnvironment:'GEM5_DIR') notNil
+		 description: 'GEM5_DIR environment not set!'.
+
+	self assert: ((OperatingSystem getEnvironment:'GEM5_DIR') asFilename / 'build' / 'RISCV' / 'gem5.opt') exists
+		 description: 'No RISC-V gem5 found in GEM5_DIR'.            
+
+	gem5cmd := '%1/build/RISCV/gem5.opt "--debug-flags=Decode" %1/configs/example/se.py -c %2 --wait-gdb --param ''system.shared_backstore = "/gem5"'''
+				bindWith: (OperatingSystem getEnvironment:'GEM5_DIR')
+					with: debugger pathName.
+
+	"First, start gem5..."
+	gem5 := OSProcess new command: gem5cmd.
+	gem5 startProcess.
+	"...and give it a time initialize itself..."
+	Delay waitForSeconds: 1.   
+
+	target := GDBDebugger new.
+	target executable: debugger.
+	target send: 'target remote localhost:7000'
+]
+
+{ #category : #running }
+TRCompilationTestShellGem5 >> tearDown [
+	super tearDown.
+	gem5 notNil ifTrue: [ 
+		gem5 waitUntilFinishedWithTimeout: 1
+	].
+]

--- a/src/Tinyrossa-Tests/TRCompilationTestShellQEMU.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestShellQEMU.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #TRCompilationTestShellQEMU,
+	#superclass : #TRCompilationTestShell,
+	#instVars : [
+		'qemu'
+	],
+	#category : #'Tinyrossa-Tests-Shells-SmalltalkX'
+}
+
+{ #category : #running }
+TRCompilationTestShellQEMU >> setUp [
+	| qemuCmd |
+
+	super setUp.
+
+	qemuCmd := 'qemu-',(target name upTo:$-),'-static'.
+
+	self assert: (OperatingSystem pathOfCommand: qemuCmd) notNil description: 'QEMU not found'.
+	"First, start QEMU... "
+	qemu := OSProcess new command: qemuCmd , ' -g 1234 ', binary pathName.
+	qemu startProcess.
+	"...and give it a time initialize itself..."
+	Delay waitForSeconds: 1.
+
+	"...then create a new GDB and connect to QEMU: "
+	debugger := GDBDebugger new.
+	debugger executable: binary.
+	debugger targetConnect: 'remote' parameters: #('localhost:1234').
+]
+
+{ #category : #running }
+TRCompilationTestShellQEMU >> tearDown [
+	super tearDown.
+	qemu notNil ifTrue: [ 
+		qemu waitUntilFinishedWithTimeout: 1
+	].
+]

--- a/src/Tinyrossa-Tests/TRCompilationTestShellRemote.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestShellRemote.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #TRCompilationTestShellRemote,
+	#superclass : #TRCompilationTestShell,
+	#classVars : [
+		'Host'
+	],
+	#category : #'Tinyrossa-Tests-Shells-SmalltalkX'
+}
+
+{ #category : #accessing }
+TRCompilationTestShellRemote class >> host [
+	^ Host isNil ifTrue: [ 'unleashed' ] ifFalse: [ Host ]
+]
+
+{ #category : #accessing }
+TRCompilationTestShellRemote class >> host: aString [
+	Host := aString
+]
+
+{ #category : #running }
+TRCompilationTestShellRemote >> setUp [
+	super setUp.
+
+	self assert: (OperatingSystem executeCommand: 'scp ' , debugger pathName , ' ' , self class host , ':/tmp')
+		 description: 'Cannot upload shell'.
+
+	target := GDBDebugger new.
+	target executable: debugger.
+	target send: 'target extended-remote | ssh -C ', self class host , ' /opt/gdb/bin/gdbserver - /tmp/' , debugger baseName.
+]

--- a/src/Tinyrossa/TRCompilationExamples.class.st
+++ b/src/Tinyrossa/TRCompilationExamples.class.st
@@ -226,10 +226,3 @@ TRCompilationExamples >> setUp [
 	super setUp.
 	compilation := TRCompilation forConfig: TRCompilationConfig forRV64GLinux
 ]
-
-{ #category : #running }
-TRCompilationExamples >> tearDown [
-	"common cleanup - invoked after testing."
-
-	super tearDown
-]

--- a/stx/GNUmakefile
+++ b/stx/GNUmakefile
@@ -6,7 +6,7 @@ include GNUmakefile.local
 include ../3rdparty.gmk
 include ../stx.gmk
 
-build: $(STX) $(MACHINEARITHMETIC_DIR) $(ARCHC_DIR) $(ARCHC_PDL_DIR) $(LIBGDBS_DIR)
+build: $(STX) $(MACHINEARITHMETIC_DIR) $(ARCHC_DIR) $(ARCHC_PDL_DIR) $(LIBGDBS_DIR) shells
 	@echo "To run Smalltalk/X with $(PROJECT) loaded, run:"
 	@echo ""
 	@echo "    make run"
@@ -31,11 +31,15 @@ test: build
 		--package-path ../src \
 		--load BaselineOf$(PROJECT) \
 		--run Builder::ReportRunner -r Builder::TestReport --fail-on-failure \
-			-p $(PROJECT)
+			-p $(PROJECT) \
+			-p $(PROJECT)-Tests-RISCV
+
+shells:
+	make -C ../shell
 
 clean::
 	rm -rf *Test.xml package-cache
 
 mrproper:: clean
 
-.PHONY: all build run test clean mrproper
+.PHONY: all build run test shells clean mrproper

--- a/stx/GNUmakefile
+++ b/stx/GNUmakefile
@@ -6,7 +6,7 @@ include GNUmakefile.local
 include ../3rdparty.gmk
 include ../stx.gmk
 
-build: $(STX) $(MACHINEARITHMETIC_DIR) $(ARCHC_DIR) $(ARCHC_PDL_DIR)
+build: $(STX) $(MACHINEARITHMETIC_DIR) $(ARCHC_DIR) $(ARCHC_PDL_DIR) $(LIBGDBS_DIR)
 	@echo "To run Smalltalk/X with $(PROJECT) loaded, run:"
 	@echo ""
 	@echo "    make run"

--- a/stx/GNUmakefile
+++ b/stx/GNUmakefile
@@ -13,20 +13,22 @@ build: $(STX) $(MACHINEARITHMETIC_DIR) $(ARCHC_DIR) $(ARCHC_PDL_DIR)
 	@echo ""
 
 
-run: $(STX) $(MACHINEARITHMETIC_DIR) $(ARCHC_DIR) $(ARCHC_PDL_DIR)
+run: build
 	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(STX) \
 		--quick \
 		--package-path $(MACHINEARITHMETIC_DIR) \
 		--package-path $(ARCHC_DIR) \
-		--package-path .. \
+		--package-path $(LIBGDBS_DIR)/../.. \
+		--package-path ../src \
 		--load BaselineOf$(PROJECT) \
-		# --execute 'Tools::NewSystemBrowser openInClass: TRCompilationExampled selector: #example01_meaningOfLife'
+		#--execute 'Tools::NewSystemBrowser openInClass: TRCompilationExamples selector: #example01_meaningOfLife'
 
-test: $(STX) $(MACHINEARITHMETIC_DIR) $(ARCHC_DIR) $(ARCHC_PDL_DIR)
+test: build
 	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(STX) \
 		--package-path $(MACHINEARITHMETIC_DIR) \
 		--package-path $(ARCHC_DIR) \
-		--package-path .. \
+		--package-path $(LIBGDBS_DIR)/../.. \
+		--package-path ../src \
 		--load BaselineOf$(PROJECT) \
 		--run Builder::ReportRunner -r Builder::TestReport --fail-on-failure \
 			-p $(PROJECT)
@@ -35,3 +37,5 @@ clean::
 	rm -rf *Test.xml package-cache
 
 mrproper:: clean
+
+.PHONY: all build run test clean mrproper


### PR DESCRIPTION
Add infrastructure and tests to test compiled code on simulators or real hardware.

This (monster) PR adds:

 * "test shells", a simple programs to load into simulators and inject
   compiled code

 * `TRCompilationTestCase` - a base superclass for all "compilation" tests
   that compile some code and then run it in the simulator / dev board.

 * and finally, `TRRV64GCompilationTests` which uses the above to test
   behavior of (some) `TRCompilationExamples` on RISC-V.

For now, all this only works for Smalltalk/X since it (for now) uses
`jv:libgdbs` and some Smalltalk/X specific API to run QEMU.

Support for Pharo using `SmallRSP` instead if `jv:libgdbs` is left as
future work.