### PR TITLE
Disallow multiple assignments to vregs

### DIFF
--- a/src/Tinyrossa-POWER/TRPPC64CodeEvaluator.class.st
+++ b/src/Tinyrossa-POWER/TRPPC64CodeEvaluator.class.st
@@ -123,17 +123,11 @@ TRPPC64CodeEvaluator >> evaluate_ificmpne: node [
 
 { #category : #evaluation }
 TRPPC64CodeEvaluator >> evaluate_iload: node [
-	"superclass TRILEvaluator says that I am responsible to implement this method"
-
 	| symbol dstReg |
 
 	symbol := node symbol.
-	dstReg := symbol register.
-	dstReg isNil ifTrue: [ 
-		dstReg := codegen allocateRegister.
-		symbol setRegister: dstReg.
-		generate lwz: dstReg, (gr1 + (AcDSLSymbol value: symbol name)).
-	].
+	dstReg := codegen allocateRegister.
+	generate lwz: dstReg, (gr1 + (AcDSLSymbol value: symbol name)).
 	^ dstReg
 ]
 
@@ -152,20 +146,11 @@ TRPPC64CodeEvaluator >> evaluate_imul: node [
 
 { #category : #evaluation }
 TRPPC64CodeEvaluator >> evaluate_istore: node [
-	| symbol srcReg dstReg |
+	| symbol srcReg |
 
 	symbol := node symbol.
 	srcReg := self evaluate: node child1.
-	dstReg := symbol register.
-	dstReg isNil ifTrue: [
-		dstReg := srcReg.
-		symbol setRegister: dstReg.
-	].
-	srcReg ~~ dstReg ifTrue: [ 
-		generate addi: dstReg, srcReg, 0.
-	].
 	generate stw: srcReg, (gr1 + (AcDSLSymbol value: symbol name)).
-
 	^ nil
 ]
 

--- a/src/Tinyrossa-RISCV/TRRV64GCodeEvaluator.class.st
+++ b/src/Tinyrossa-RISCV/TRRV64GCodeEvaluator.class.st
@@ -8,6 +8,16 @@ Class {
 }
 
 { #category : #evaluation }
+TRRV64GCodeEvaluator >> evaluate_aload: node [
+	^ self evaluate_lload: node
+]
+
+{ #category : #evaluation }
+TRRV64GCodeEvaluator >> evaluate_astore: node [
+	^ self evaluate_lstore: node
+]
+
+{ #category : #evaluation }
 TRRV64GCodeEvaluator >> evaluate_goto: node [
 	generate
 		jal: zero, node symbol.
@@ -144,12 +154,8 @@ TRRV64GCodeEvaluator >> evaluate_iload: node [
 	| symbol dstReg |
 
 	symbol := node symbol.
-	dstReg := symbol register.
-	dstReg isNil ifTrue: [ 
-		dstReg := codegen allocateRegister.
-		symbol setRegister: dstReg.
-		generate lw: dstReg, (sp + (AcDSLSymbol value: symbol name)).
-	].
+	dstReg := codegen allocateRegister.
+	generate lw: dstReg, (sp + (AcDSLSymbol value: symbol name)).
 	^ dstReg
 ]
 
@@ -168,20 +174,11 @@ TRRV64GCodeEvaluator >> evaluate_imul: node [
 
 { #category : #evaluation }
 TRRV64GCodeEvaluator >> evaluate_istore: node [
-	| symbol srcReg dstReg |
+	| symbol srcReg |
 
 	symbol := node symbol.
 	srcReg := self evaluate: node child1.
-	dstReg := symbol register.
-	dstReg isNil ifTrue: [
-		dstReg := srcReg.
-		symbol setRegister: dstReg.
-	].
-	srcReg ~~ dstReg ifTrue: [ 
-		generate addi: dstReg, srcReg, 0.
-	].
 	generate sw: srcReg, (sp + (AcDSLSymbol value: symbol name)).
-
 	^ nil
 ]
 
@@ -202,4 +199,24 @@ TRRV64GCodeEvaluator >> evaluate_isub: node [
 	].
 
 	^ dstReg
+]
+
+{ #category : #evaluation }
+TRRV64GCodeEvaluator >> evaluate_lload: node [
+	| symbol dstReg |
+
+	symbol := node symbol.
+	dstReg := codegen allocateRegister.
+	generate ld: dstReg, (sp + (AcDSLSymbol value: symbol name)).
+	^ dstReg
+]
+
+{ #category : #evaluation }
+TRRV64GCodeEvaluator >> evaluate_lstore: node [
+	| symbol srcReg |
+
+	symbol := node symbol.
+	srcReg := self evaluate: node child1.
+	generate sd: srcReg, (sp + (AcDSLSymbol value: symbol name)).
+	^ nil
 ]

--- a/src/Tinyrossa/TRCodeEvaluator.class.st
+++ b/src/Tinyrossa/TRCodeEvaluator.class.st
@@ -143,7 +143,7 @@ TRCodeEvaluator >> evaluate_return: node [
 
 	retReg := self evaluate: node child1.
 	generate leave: retReg.
-	^ retReg
+	^ nil
 ]
 
 { #category : #evaluation }

--- a/src/Tinyrossa/TRILCommoner.class.st
+++ b/src/Tinyrossa/TRILCommoner.class.st
@@ -10,25 +10,46 @@ Class {
 	#category : #'Tinyrossa-Optimizer'
 }
 
+{ #category : #commoning }
+TRILCommoner >> common: node [
+	| op |
+
+	op := node opcode.
+
+	"Replace 'load x' following 'store v into x' by just 'v', elimitinating
+	 the load (and hopefully the store too).
+
+	 This does not handle indirect loads/stores nor read/write barriers.
+	"
+	op isIndirect ifFalse: [ 
+		(op isStore and: [ op isWriteBarrierStore not]) ifTrue: [ 
+			stores at: node symbol put: node.
+			^ node.
+		].
+		(op isLoadVar and: [ op isReadBarrierLoad not]) ifTrue: [ 
+			| store |
+
+			store := stores at: node symbol ifAbsent: [ nil ].
+			store notNil ifTrue: [ 
+				^ store child1
+			].
+		]                
+	].
+	^ node
+
+	"
+	TRILOpcodes all select:[:op | op isStore]
+	TRILOpcodes all select:[:op | op isLoad]
+	"
+]
+
+{ #category : #evaluation }
+TRILCommoner >> evaluate: node [
+	^ self common: (super evaluate: node)
+]
+
 { #category : #evaluation }
 TRILCommoner >> evaluate_bbstart: node [
 	stores := Dictionary new.
-	^ node
-]
-
-{ #category : #evaluation }
-TRILCommoner >> evaluate_iload: node [    
-	| store |
-
-	store := stores at: node symbol ifAbsent: [ nil ].
-	store notNil ifTrue: [ 
-		^ store child1
-	].
-	^ node
-]
-
-{ #category : #evaluation }
-TRILCommoner >> evaluate_istore: node [
-	stores at: node symbol put: node.
 	^ node
 ]

--- a/src/Tinyrossa/TRILCommoner.class.st
+++ b/src/Tinyrossa/TRILCommoner.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #TRILCommoner,
 	#superclass : #TRILRewritingPass,
 	#instVars : [
-		'stores'
+		'stores',
+		'loads'
 	],
 	#pools : [
 		'TRILOpcodes'
@@ -27,12 +28,18 @@ TRILCommoner >> common: node [
 			^ node.
 		].
 		(op isLoadVar and: [ op isReadBarrierLoad not]) ifTrue: [ 
-			| store |
+			| store load |
 
 			store := stores at: node symbol ifAbsent: [ nil ].
 			store notNil ifTrue: [ 
 				^ store child1
 			].
+
+			load := loads at: node symbol ifAbsent: [ nil ].
+			load notNil ifTrue: [ 
+				^ load.
+			].
+			loads at: node symbol put: node.            
 		]                
 	].
 	^ node
@@ -51,5 +58,6 @@ TRILCommoner >> evaluate: node [
 { #category : #evaluation }
 TRILCommoner >> evaluate_bbstart: node [
 	stores := Dictionary new.
+	loads := Dictionary new.
 	^ node
 ]

--- a/src/Tinyrossa/TRILNode.class.st
+++ b/src/Tinyrossa/TRILNode.class.st
@@ -215,20 +215,21 @@ TRILNode >> setBlock: aTRILBlock [
 TRILNode >> setResult: vreg [
 	opcode type == Void ifTrue: [ 
 		self assert: vreg isNil description: 'Attempting to set result for void-typed node'.
+		^ self.
 	].
-	vreg isNil ifTrue: [
-		self assert: opcode isTreeTop.
-	] ifFalse:[
-		opcode type isIntegerType ifTrue: [ 
-			self assert: vreg notNil.
-			self assert: vreg kind == GPR
-		] ifFalse: [ 
-			self assert: vreg notNil.
-			self assert: vreg kind == FPR
-		].
+	opcode isTreeTop ifTrue: [ 
+		self assert: vreg isNil description: 'Attempting to set result of tree-top'.
+		^ self.
 	].
-
+	opcode type isIntegerType ifTrue: [ 
+		self assert: vreg notNil.
+		self assert: vreg kind == GPR
+	] ifFalse: [ 
+		self assert: vreg notNil.
+		self assert: vreg kind == FPR
+	].
 	self assert: result isNil description: 'Node already evaluated!'.
+	vreg setAssigned.
 	result := vreg.
 ]
 

--- a/src/Tinyrossa/TRILOpcode.class.st
+++ b/src/Tinyrossa/TRILOpcode.class.st
@@ -182,6 +182,16 @@ TRILOpcode >> isLoadConst [
 ]
 
 { #category : #testing }
+TRILOpcode >> isLoadVar [
+	^ props1 anyMask: LoadVar
+]
+
+{ #category : #testing }
+TRILOpcode >> isReadBarrierLoad [
+	^ props3 anyMask: ReadBarrierLoad
+]
+
+{ #category : #testing }
 TRILOpcode >> isReturn [
 	^ props1 anyMask: Return
 ]
@@ -201,6 +211,11 @@ TRILOpcode >> isTreeTop [
 	 *        node in another circumstance.
 	 *"
 	^ props1 anyMask: TreeTop
+]
+
+{ #category : #testing }
+TRILOpcode >> isWriteBarrierStore [
+	^ props3 anyMask: WriteBarrierStore
 ]
 
 { #category : #accessing }

--- a/src/Tinyrossa/TRRealRegister.class.st
+++ b/src/Tinyrossa/TRRealRegister.class.st
@@ -32,3 +32,8 @@ TRRealRegister >> initializeWithValue: anAcAsmMapEntry kind: aTRRegisterKind [
 TRRealRegister >> kind [
 	^ kind
 ]
+
+{ #category : #initialization }
+TRRealRegister >> setAssigned [
+	"No-op, we do not track assignments to real registers"
+]

--- a/src/Tinyrossa/TRVirtualRegister.class.st
+++ b/src/Tinyrossa/TRVirtualRegister.class.st
@@ -5,6 +5,7 @@ Class {
 		'name',
 		'kind',
 		'constraints',
+		'assigned',
 		'allocation'
 	],
 	#category : #'Tinyrossa-Codegen'
@@ -72,7 +73,13 @@ TRVirtualRegister >> hasConstraints [
 TRVirtualRegister >> initializeWithName: aString kind: aTRRegisterKind [
 	name := aString.
 	kind := aTRRegisterKind.
-	name := aString
+	name := aString.
+	assigned := false.
+]
+
+{ #category : #testing }
+TRVirtualRegister >> isAssigned [
+	^ assigned
 ]
 
 { #category : #testing }
@@ -102,6 +109,13 @@ TRVirtualRegister >> printOn:aStream [
 		allocation printOn: aStream.
 	].
 	aStream nextPut:$).
+]
+
+{ #category : #initialization }
+TRVirtualRegister >> setAssigned [
+	" self assert: assigned == false description: 'Attempting to assign into virtual register twice!'."
+
+	assigned := true.
 ]
 
 { #category : #conversion }


### PR DESCRIPTION
This commit makes sure that - at TRIL level - virtual registers are assigned only once
to facilitate proofs using MA. The crux of this PR is commit 8788e353c5e3bc449436d27d300800d98e842040. 