### PR TITLE
Use LibGDBs also on Pharo

### DIFF
--- a/pharo/GNUmakefile
+++ b/pharo/GNUmakefile
@@ -8,6 +8,7 @@ all: build
 -include GNUmakefile.local
 include ../makefiles/pharo.gmk
 include ../makefiles/git.gmk
+include ../makefiles/mercurial.gmk
 
 ifndef MACHINEARITHMETIC_DIR
 MACHINEARITHMETIC_DIR    := ../3rdparty/MachineArithmetic
@@ -44,12 +45,29 @@ PHARO_HACKS_BRANCH ?= master
 $(eval $(call git-clone-local,PHARO_HACKS_DIR,$(PHARO_HACKS_URL),$(PHARO_HACKS_BRANCH)))
 endif
 
+ifndef PTERM_DIR
+PTERM_DIR    := ../3rdparty/PTerm
+PTERM_URL    ?= https://github.com/janvrany/PTerm
+PTERM_BRANCH ?= master
+$(eval $(call git-clone-local,PTERM_DIR,$(PTERM_URL),$(PTERM_BRANCH)))
+endif
+
+ifndef LIBGDBS_DIR
+LIBGDBS_DIR    := ../3rdparty/jv/libgdbs
+LIBGDBS_URL    ?= https://jan.vrany.io/hg/jv-libgdbs
+LIBGDBS_BRANCH ?= default
+$(eval $(call mercurial-clone-local,LIBGDBS_DIR,$(LIBGDBS_URL),$(LIBGDBS_BRANCH)))
+endif
+
 build: prereq $(PROJECT).image shells
 	@echo ""
 	@echo "To open Pharo $(PROJECT) image run:"
 	@echo ""
 	@echo "    make run"
 	@echo ""
+
+prereq::
+	$(MAKE) -C $(LIBGDBS_DIR)/ports/pharo source
 
 $(PROJECT).image: ../src/*/*.st
 	$(call pharo-copy-image, $(PHARO_IMAGE), $@)
@@ -58,6 +76,9 @@ $(PROJECT).image: ../src/*/*.st
 	$(call pharo-load-local, $@, SmallRSP,         $(SMALLRSP_DIR)/src)
 	$(call pharo-load-local, $@, LibUnix,          $(PHARO_HACKS_DIR)/src)
 	$(call pharo-load-local, $@, LibCompat,        $(PHARO_HACKS_DIR)/src)
+	$(call pharo-load-local, $@, LibUnix,          $(PHARO_HACKS_DIR)/src)
+	$(call pharo-load-local, $@, PTerm,            $(PTERM_DIR))
+	$(call pharo-load-local, $@, LibGDBs,          $(LIBGDBS_DIR)/ports/pharo/src-generated)
 	$(call pharo-load-local, $@, Tinyrossa,        ../src)
 
 run: build

--- a/pharo/GNUmakefile
+++ b/pharo/GNUmakefile
@@ -86,8 +86,10 @@ run: build
 
 test: build
 	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(PHARO_VM_HEADLESS) $(PROJECT).image test --fail-on-failure \
-		"$(PROJECT)" \
-		"$(PROJECT)-Tests"
+		$(PROJECT) \
+		$(PROJECT)-Tests \
+		$(PROJECT)-Tests-RISCV \
+		$(PROJECT)-Tests-POWER
 
 shells:
 	make -C ../shell

--- a/src/Tinyrossa-Tests-RISCV/TRRV64GCompilationTests.class.st
+++ b/src/Tinyrossa-Tests-RISCV/TRRV64GCompilationTests.class.st
@@ -68,7 +68,7 @@ TRRV64GCompilationTests >> test03_lconst_n [
 	 VDBDebuggerApplication openFor: debugger
 	"
 	debugger c.
-	self assert: (debugger getRegister: 'a0') hex equals: '-7AFEAFFECAFEAFFE'.
+	self assert: (debugger getRegister: 'a0')  equals: -16r7AFEAFFECAFEAFFE.
 ]
 
 { #category : #tests }

--- a/src/Tinyrossa-Tests/TRCompilationTestShell.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestShell.class.st
@@ -110,27 +110,21 @@ TRCompilationTestShell >> setUp [
 
 { #category : #'running-private' }
 TRCompilationTestShell >> setUpDebuggerOnHost: host port: port [
-	Smalltalk isSmalltalkX ifTrue:[
-		"On Smalltalk/X we use jv:libgdbs to poke at shell."
+	(Smalltalk includesKey: #GDBDebugger) ifTrue:[
+		"Use LibGDBs if available..."
 		
-		self assert: (Smalltalk includesKey: #GDBDebugger).
-
 		debugger := (Smalltalk at: #GDBDebugger) new.
 		debugger executable: binary.
 		debugger send: 'target remote ', host , ':' , port printString.
 		^self
-	].
-
-	Smalltalk isPharo ifTrue:[
-		"On Pharo, we se ULD (SmallRSP) to poke at shell."
+	] ifFalse:[
+		"...else use SmallRSP."
 	
 		self assert: (Smalltalk includesKey: #RemoteGDB).
 
 		debugger := (Smalltalk at: #RemoteGDB) host: host port: port.
 		^self.
 	].
-
-	self error:'Unsupported dialect'
 ]
 
 { #category : #running }
@@ -140,23 +134,25 @@ TRCompilationTestShell >> tearDown [
 
 { #category : #'running-private' }
 TRCompilationTestShell >> tearDownDebugger [
-	Smalltalk isSmalltalkX ifTrue:[
-		"On Smalltalk/X we use jv:libgdbs to poke at shell."
+	(debugger class name = #GDBDebugger) ifTrue:[
+		"debugger is LibGDBs' GDBDebugger..."
 		
 		(debugger notNil and: [ debugger isConnected ]) ifTrue: [
+			| shouldQuitDebugger |
+			
 			debugger send: 'kill'.
-			(Smalltalk includesKey: #VDBDebuggerApplication) ifTrue: [
-				((Smalltalk at: #VDBDebuggerApplication) allInstances allSatisfy:[:vdbApp | vdbApp debugger ~~ target]) ifTrue: [ 
-					debugger send: 'quit' andWait: false.
-				].
+			
+			shouldQuitDebugger := (Smalltalk includesKey: #VDBDebuggerApplication) not 
+														or:[(Smalltalk at: #VDBDebuggerApplication) allInstances allSatisfy:[:vdbApp | vdbApp debugger ~~ target]].
+			shouldQuitDebugger ifTrue: [ 
+					debugger send: 'quit' andWait: false.				
 			].
+		].		
+	] ifFalse:[
+		"debugger is either nil or SmallRSP's RemoteGDB"
+		debugger notNil ifTrue:[		
+			debugger disconnect.
 		].
-		
-	].
-	Smalltalk isPharo ifTrue:[
-		"On Pharo, we se ULD (SmallRSP) to poke at shell."
-		
-		debugger disconnect.
 	].
 	debugger := nil.
 ]

--- a/stx/GNUmakefile
+++ b/stx/GNUmakefile
@@ -33,7 +33,7 @@ endif
 
 ifndef LIBGDBS_DIR
 LIBGDBS_DIR    := ../3rdparty/jv/libgdbs
-LIBGDBS_URL    ?= https://swing.fit.cvut.cz/hg/jv-libgdbs
+LIBGDBS_URL    ?= https://jan.vrany.io/hg/jv-libgdbs
 LIBGDBS_BRANCH ?= default
 $(eval $(call mercurial-clone-local,LIBGDBS_DIR,$(LIBGDBS_URL),$(LIBGDBS_BRANCH)))
 endif


### PR DESCRIPTION
This PR makes use of LibGDBs Pharo Port to drive compilation tests. `SmallRSP` is still loaded into Pharo image but not used by default. 

This allows us to run compilation tests also on Pharo on QEMU as SmallRSP crashed when trying to connect to QEMU.