### PR TITLE
Use improved Gem5 SE config for running tests when using Gem5

### DIFF
--- a/shell/shell-gem5.py
+++ b/shell/shell-gem5.py
@@ -1,0 +1,377 @@
+# Copyright (c) 2012-2013 ARM Limited
+# Copyright (c) 2023-2023 LabWare
+# All rights reserved.
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+#
+# Copyright (c) 2006-2008 The Regents of The University of Michigan
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# gem5 config to run (not only) shell under gem5 SE. Essentially
+# modified se.py from gem5.
+#
+
+import argparse
+import sys
+import os
+import os.path
+
+if __name__ != "__m5_main__":
+    print("This file must be run under gem5!", file=sys.stderr)
+    sys.exit(1)
+
+import m5
+from m5.defines import buildEnv
+from m5.objects import *
+from m5.params import NULL
+from m5.util import addToPath, fatal, warn
+from gem5.isas import ISA
+from gem5.runtime import get_runtime_isa, get_supported_isas
+
+if os.getenv("GEM5_DIR") is None:
+    fatal("GEM5_DIR environment is not set, do not know where to find gem5 sources")
+
+if not os.path.isdir(os.path.join(os.getenv("GEM5_DIR"), 'configs')):
+    fatal("GEM5_DIR environment is not set, do not know where to find simulation configs.")
+
+addToPath(os.path.join(os.getenv("GEM5_DIR"), 'configs'))
+
+def get_processes(args):
+    """Interprets provided args and returns a list of processes"""
+
+    multiprocesses = []
+    inputs = []
+    outputs = []
+    errouts = []
+    pargs = []
+
+    workloads = args.cmd.split(";")
+    if args.input != "":
+        inputs = args.input.split(";")
+    if args.output != "":
+        outputs = args.output.split(";")
+    if args.errout != "":
+        errouts = args.errout.split(";")
+    if args.options != "":
+        pargs = args.options.split(";")
+
+    idx = 0
+    for wrkld in workloads:
+        process = Process(pid=100 + idx)
+        process.executable = wrkld
+        process.cwd = os.getcwd()
+        process.gid = os.getgid()
+
+        if args.env:
+            with open(args.env, "r") as f:
+                process.env = [line.rstrip() for line in f]
+
+        if len(pargs) > idx:
+            process.cmd = [wrkld] + pargs[idx].split()
+        else:
+            process.cmd = [wrkld]
+
+        if len(inputs) > idx:
+            process.input = inputs[idx]
+        if len(outputs) > idx:
+            process.output = outputs[idx]
+        if len(errouts) > idx:
+            process.errout = errouts[idx]
+
+        multiprocesses.append(process)
+        idx += 1
+
+    if args.smt:
+        assert args.cpu_type == "DerivO3CPU"
+        return multiprocesses, idx
+    else:
+        return multiprocesses, 1
+
+
+#
+# Following constants are taken from elf.h.
+#
+ELFMAG = b"\177ELF"
+
+EI_DATA = 5  #  Data encoding byte index
+ELFDATANONE = 0  #  Invalid data encoding
+ELFDATA2LSB = 1  #  2's complement, little endian
+ELFDATA2MSB = 2  #  2's complement, big endian
+
+# Legal values for e_machine (architecture).
+EM_NONE = 0  #  No machine
+EM_SPARC = 2  #  SUN SPARC
+EM_386 = 3  #  Intel 80386
+EM_MIPS = 8  #  MIPS R3000 big-endian
+EM_MIPS_RS3_LE = 10  #  MIPS R3000 little-endian
+EM_PPC = 20  #  PowerPC
+EM_PPC64 = 21  #  PowerPC 64-bit
+EM_ARM = 40  #  ARM
+EM_X86_64 = 62  #  AMD x86-64 architecture
+EM_AARCH64 = 183  #  ARM AARCH64
+EM_AMDGPU = 224  #  AMD GPU
+EM_RISCV = 243  #  RISC-V
+
+# Non-standard
+EI_E_MACHINE = 18  # e_machine first byte index
+
+
+def set_isa(args):
+    """
+    Set the architecture based on executable (if this gem5 has
+    support for multiple architectures).
+    """
+    if len(get_supported_isas()) > 1:
+        exe_path = args.cmd.split(";")[0]
+        with open(exe_path, mode="br") as exe:
+            # Code below essentially reads an ELF header
+            # and set the ISA based on e_machine value.
+            # Everything is hard-coded here to avoid pulling
+            # in more dependencies.
+
+            ehdr = exe.read(
+                16 + 2 + 2
+            )  # EI_NIDENT=16 + e_type=2 + e_machibe=2
+            if ehdr[0:4] != ELFMAG:
+                fatal(f"Invalid ELF executable: {exe_path}")
+
+            if ehdr[EI_DATA] == ELFDATA2LSB:
+                e_machine = (ehdr[EI_E_MACHINE + 1] << 8) + ehdr[EI_E_MACHINE]
+            elif ehdr[5] == 2:
+                e_machine = (ehdr[EI_E_MACHINE] << 8) + ehdr[EI_E_MACHINE + 1]
+            else:
+                fatal(f"Invalid ELF data encoding ({ehdr[5]}): {exe_path}")
+
+            if e_machine in (EM_SPARC,):
+                isa = "Sparc"
+            elif e_machine in (EM_386, EM_X86_64):
+                isa = "X86"
+            elif e_machine in (EM_MIPS, EM_MIPS_RS3_LE):
+                isa = "Mips"
+            elif e_machine in (EM_PPC, EM_PPC64):
+                isa = "Power"
+            elif e_machine in (EM_ARM, EM_AARCH64):
+                isa = "Arm"
+            elif e_machine in (EM_RISCV,):
+                isa = "Riscv"
+            else:
+                fatal(f"Unsupported ELF machine ({e_machine}): {exe_path}")
+
+            print(f"info: Target ISA is {isa}")
+
+            buildEnv["TARGET_ISA"] = isa
+            args.cpu_type = f"{isa}AtomicSimpleCPU"
+
+from common import Options
+
+parser = argparse.ArgumentParser()
+Options.addCommonOptions(parser)
+Options.addSEOptions(parser)
+
+if "--ruby" in sys.argv:
+    Ruby.define_options(parser)
+
+args = parser.parse_args()
+
+# set_isa must be called before below imports
+# since TARGET_ISA has to be set before importing
+# CacheConfig (which still uses get_runtime_isa())
+set_isa(args)
+
+from ruby import Ruby
+from common import Simulation
+from common import CacheConfig
+from common import CpuConfig
+from common import ObjectList
+from common import MemConfig
+from common.FileSystemConfig import config_filesystem
+from common.Caches import *
+from common.cpu2000 import *
+
+multiprocesses = []
+numThreads = 1
+
+if args.bench:
+    apps = args.bench.split("-")
+    if len(apps) != args.num_cpus:
+        print("number of benchmarks not equal to set num_cpus!")
+        sys.exit(1)
+
+    for app in apps:
+        try:
+            if get_runtime_isa() == ISA.ARM:
+                exec(
+                    "workload = %s('arm_%s', 'linux', '%s')"
+                    % (app, args.arm_iset, args.spec_input)
+                )
+            else:
+                # TARGET_ISA has been removed, but this is missing a ], so it
+                # has incorrect syntax and wasn't being used anyway.
+                exec(
+                    "workload = %s(buildEnv['TARGET_ISA', 'linux', '%s')"
+                    % (app, args.spec_input)
+                )
+            multiprocesses.append(workload.makeProcess())
+        except:
+            print(
+                f"Unable to find workload for {get_runtime_isa().name()}: {app}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+elif args.cmd:
+    multiprocesses, numThreads = get_processes(args)
+else:
+    print("No workload specified. Exiting!\n", file=sys.stderr)
+    sys.exit(1)
+
+(CPUClass, test_mem_mode, FutureClass) = Simulation.setCPUClass(args)
+CPUClass.numThreads = numThreads
+
+# Check -- do not allow SMT with multiple CPUs
+if args.smt and args.num_cpus > 1:
+    fatal("You cannot use SMT with multiple CPUs!")
+
+np = args.num_cpus
+mp0_path = multiprocesses[0].executable
+system = System(
+    cpu=[CPUClass(cpu_id=i) for i in range(np)],
+    mem_mode=test_mem_mode,
+    mem_ranges=[AddrRange(args.mem_size)],
+    cache_line_size=args.cacheline_size,
+)
+
+if numThreads > 1:
+    system.multi_thread = True
+
+# Create a top-level voltage domain
+system.voltage_domain = VoltageDomain(voltage=args.sys_voltage)
+
+# Create a source clock for the system and set the clock period
+system.clk_domain = SrcClockDomain(
+    clock=args.sys_clock, voltage_domain=system.voltage_domain
+)
+
+# Create a CPU voltage domain
+system.cpu_voltage_domain = VoltageDomain()
+
+# Create a separate clock domain for the CPUs
+system.cpu_clk_domain = SrcClockDomain(
+    clock=args.cpu_clock, voltage_domain=system.cpu_voltage_domain
+)
+
+# If elastic tracing is enabled, then configure the cpu and attach the elastic
+# trace probe
+if args.elastic_trace_en:
+    CpuConfig.config_etrace(CPUClass, system.cpu, args)
+
+# All cpus belong to a common cpu_clk_domain, therefore running at a common
+# frequency.
+for cpu in system.cpu:
+    cpu.clk_domain = system.cpu_clk_domain
+
+if ObjectList.is_kvm_cpu(CPUClass) or ObjectList.is_kvm_cpu(FutureClass):
+    if buildEnv["USE_X86_ISA"]:
+        system.kvm_vm = KvmVM()
+        system.m5ops_base = 0xFFFF0000
+        for process in multiprocesses:
+            process.useArchPT = True
+            process.kvmInSE = True
+    else:
+        fatal("KvmCPU can only be used in SE mode with x86")
+
+# Sanity check
+if args.simpoint_profile:
+    if not ObjectList.is_noncaching_cpu(CPUClass):
+        fatal("SimPoint/BPProbe should be done with an atomic cpu")
+    if np > 1:
+        fatal("SimPoint generation not supported with more than one CPUs")
+
+for i in range(np):
+    if args.smt:
+        system.cpu[i].workload = multiprocesses
+    elif len(multiprocesses) == 1:
+        system.cpu[i].workload = multiprocesses[0]
+    else:
+        system.cpu[i].workload = multiprocesses[i]
+
+    if args.simpoint_profile:
+        system.cpu[i].addSimPointProbe(args.simpoint_interval)
+
+    if args.checker:
+        system.cpu[i].addCheckerCpu()
+
+    if args.bp_type:
+        bpClass = ObjectList.bp_list.get(args.bp_type)
+        system.cpu[i].branchPred = bpClass()
+
+    if args.indirect_bp_type:
+        indirectBPClass = ObjectList.indirect_bp_list.get(
+            args.indirect_bp_type
+        )
+        system.cpu[i].branchPred.indirectBranchPred = indirectBPClass()
+
+    system.cpu[i].createThreads()
+
+if args.ruby:
+    Ruby.create_system(args, False, system)
+    assert args.num_cpus == len(system.ruby._cpu_ports)
+
+    system.ruby.clk_domain = SrcClockDomain(
+        clock=args.ruby_clock, voltage_domain=system.voltage_domain
+    )
+    for i in range(np):
+        ruby_port = system.ruby._cpu_ports[i]
+
+        # Create the interrupt controller and connect its ports to Ruby
+        # Note that the interrupt controller is always present but only
+        # in x86 does it have message ports that need to be connected
+        system.cpu[i].createInterruptController()
+
+        # Connect the cpu's cache ports to Ruby
+        ruby_port.connectCpuPorts(system.cpu[i])
+else:
+    MemClass = Simulation.setMemClass(args)
+    system.membus = SystemXBar()
+    system.system_port = system.membus.cpu_side_ports
+    CacheConfig.config_cache(args, system)
+    MemConfig.config_mem(args, system)
+    config_filesystem(system, args)
+
+system.workload = SEWorkload.init_compatible(mp0_path)
+
+if args.wait_gdb:
+    system.workload.wait_for_remote_gdb = True
+
+root = Root(full_system=False, system=system)
+Simulation.run(args, root, system, FutureClass)

--- a/src/Tinyrossa-Tests/TRCompilationTestShellGem5.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestShellGem5.class.st
@@ -22,22 +22,31 @@ TRCompilationTestShellGem5 class >> host: aString [
 
 { #category : #running }
 TRCompilationTestShellGem5 >> setUp [
-	| gem5dir gem5exe gem5cmd |
+	| shellDir gem5dir gem5exe gem5cmd |
 
 	super setUp.
+
+	shellDir := self class shellDirectory.      
+	self assert: shellDir notNil description:'Could not determine directory with test shells!'.        
 
 	gem5dir := Smalltalk os getEnvironment: 'GEM5_DIR'.
 	self assert: gem5dir notNil description: 'GEM5_DIR environment not set!'.
 
-	gem5exe := gem5dir asFileReference / 'build' / target gem5 / 'gem5.debug'.
+	gem5exe := gem5dir asFileReference / 'build' / 'ALL' / 'gem5.debug'.
+	gem5exe exists ifFalse: [ 
+		gem5exe := gem5dir asFileReference / 'build' / 'ALL' / 'gem5.debug'.
+	].
+	gem5exe exists ifFalse: [ 
+		gem5exe := gem5dir asFileReference / 'build' / target gem5 / 'gem5.opt'.
+	].
 	gem5exe exists ifFalse: [ 
 		gem5exe := gem5dir asFileReference / 'build' / target gem5 / 'gem5.opt'.
 	].
 
-	self assert: gem5exe exists description: 'No gem5.debug nor gem5.opt found in GEM5_DIR/build/',target gem5.            
+	self assert: gem5exe exists description: 'No gem5.debug nor gem5.opt found in GEM5_DIR/build/ALL nor GEM5_DIR/build/',target gem5.            
 
-	gem5cmd := '<1s> --listener-mode on "--debug-flags=Decode" <2s>/configs/example/se.py -c <3s> --wait-gdb --param ''system.shared_backstore = "/gem5"'''
-				expandMacrosWith: gem5exe pathString with: gem5dir with: binary pathString.
+	gem5cmd := '<1s> --listener-mode on "--debug-flags=Decode" <2s>/shell-gem5.py -c <3s> --wait-gdb --param ''system.shared_backstore = "/gem5"'''
+				expandMacrosWith: gem5exe pathString with: shellDir pathString with: binary pathString.
 
 	"First, start gem5..."
 	gem5 := OSProcess new command: gem5cmd.


### PR DESCRIPTION
This commit adds an improved config for running test shell under recent gem5 that support multi-ISA builds of gem5. This script is based on deprecated `se.py` from gem5 [1].

[1]: https://github.com/gem5/gem5/blob/c218104f5227bc31f36dbba632b253cc6d95acdd/configs/deprecated/example/se.py
[2]: https://github.com/gem5/gem5/pull/215