### PR TITLE
Remove dependency on OSUnixSubprocess in favour of LibCompat

### DIFF
--- a/pharo/GNUmakefile
+++ b/pharo/GNUmakefile
@@ -56,6 +56,7 @@ $(PROJECT).image: ../src/*/*.st
 	$(call pharo-load-local, $@, MachineArithmetic,$(MACHINEARITHMETIC_DIR))
 	$(call pharo-load-local, $@, ArchC,            $(ARCHC_DIR)/src)
 	$(call pharo-load-local, $@, SmallRSP,         $(SMALLRSP_DIR)/src)
+	$(call pharo-load-local, $@, LibUnix,          $(PHARO_HACKS_DIR)/src)
 	$(call pharo-load-local, $@, LibCompat,        $(PHARO_HACKS_DIR)/src)
 	$(call pharo-load-local, $@, Tinyrossa,        ../src)
 

--- a/src/BaselineOfTinyrossa/BaselineOfTinyrossa.class.st
+++ b/src/BaselineOfTinyrossa/BaselineOfTinyrossa.class.st
@@ -18,18 +18,18 @@ BaselineOfTinyrossa >> baseline: spec [
 				spec repository: 'github://shingarov/SmallRSP:microwatt'
 			].
 
-			spec baseline: 'OSSubprocess' with: [
-				spec repository: 'github://pharo-contributions/OSSubprocess:v1.3.0'
+			spec baseline: 'LibCompat' with: [
+				spec repository: 'github://janvrany/pharo-hacks'.
 			].
 
-			spec baseline: 'LibCompat' with: [
+			spec baseline: 'LibUnix' with: [
 				spec repository: 'github://janvrany/pharo-hacks'.
 			].
 
 			spec
 				package: #'Tinyrossa' with:[
-					"LibCompat requires OSSubprocess for its OSProcess implementation."
-					spec requires: 'OSSubprocess'.
+					"LibCompat's implementation of OSProcess requires LibUnix"
+					spec requires: 'LibUnix'.
 					spec requires: 'LibCompat'.
 					spec requires: 'ArchC'
 				];


### PR DESCRIPTION
LibCompat since commit 76a8f9fdb5 [1] uses LibUnix instead of OSUnixSubprocess to implement OSProcess used by test shells to spawn QEMU or Gem5. Worse, due to unfortunate implementation of OSUnixSubprocess (see the aforementioned commit message) it cannot coexist with OSUnixSubprocess.

This commit follows this change in LibCompat and removes dependency on OSUnixSubprocess in favour of LibUnix.

[1]: https://github.com/janvrany/pharo-hacks/commit/76a8f9fdb5eeafaf54be0cdf2369be0e70a81812