### PR TITLE
RLSRA: correctly update register dependencies when splitting intervals

### DIFF
--- a/src/Tinyrossa/AcInstruction.extension.st
+++ b/src/Tinyrossa/AcInstruction.extension.st
@@ -35,3 +35,23 @@ AcInstruction >> node [
 AcInstruction >> node: aTRILNode [
 	^ self annotationAddOrReplace: aTRILNode
 ]
+
+{ #category : #'*Tinyrossa' }
+AcInstruction >> replaceVirtualRegistersUsing: replacementMap [
+	"Replace all references according to `replacementMap` and return
+	 new instruction.
+
+	 `replacementMap` should be a dictionary mapping old v-register NAME
+	 to new v-register ITSELF. That is, keys are strings, values are v-regs.
+
+	 This is similar to `#inEnvironment:` except it also updates register
+	 dependencies (and other Tinyrossa-specific metadata that may come
+	 in future).
+
+	 Implementation note: using strings as keys instead of original vreg
+	 this looks silly, but here we're limited by `Z3Node >> #inEnvironment:`
+	 which works with either Z3Nodes or Strings a keys.
+	"
+
+	"Nothing to do here, overriden in ProcessorInstruction"
+]

--- a/src/Tinyrossa/ProcessorInstruction.extension.st
+++ b/src/Tinyrossa/ProcessorInstruction.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #ProcessorInstruction }
+
+{ #category : #'*Tinyrossa' }
+ProcessorInstruction >> replaceVirtualRegistersUsing: replacementMap [
+	| updated |
+
+	replacementMap keysAndValuesDo: [ :name :vreg |
+		self assert: name isString.
+		self assert: vreg isTRVirtualRegister
+	].
+
+	replacementMap isEmpty ifTrue: [ ^ self ].
+
+	updated := self inEnvironment: replacementMap.
+	self dependencies notNil ifTrue: [
+		updated dependencies: (self dependencies replaceVirtualRegistersUsing: replacementMap)
+	].
+	^ updated
+]

--- a/src/Tinyrossa/TRRegisterDependencies.class.st
+++ b/src/Tinyrossa/TRRegisterDependencies.class.st
@@ -55,9 +55,22 @@ Class {
 
 { #category : #'instance creation' }
 TRRegisterDependencies class >> new [
-	"return an initialized instance"
+	^ self pre: TRRegisterDependencyGroup new post: TRRegisterDependencyGroup new
+]
 
-	^ self basicNew initialize.
+{ #category : #'instance creation' }
+TRRegisterDependencies class >> post: postDependencyGroup [
+	^ self pre: TRRegisterDependencyGroup new post: postDependencyGroup
+]
+
+{ #category : #'instance creation' }
+TRRegisterDependencies class >> pre: preDependencyGroup [
+	^ self pre: preDependencyGroup post: TRRegisterDependencyGroup new
+]
+
+{ #category : #'instance creation' }
+TRRegisterDependencies class >> pre: pre post: post [
+	^ self basicNew initializeWithPre: pre post: post.
 ]
 
 { #category : #'adding & removing' }
@@ -77,9 +90,9 @@ TRRegisterDependencies >> addPreDependencyOf: vreg on: rreg [
 ]
 
 { #category : #initialization }
-TRRegisterDependencies >> initialize [
-	pre := TRRegisterDependencyGroup new.
-	post := TRRegisterDependencyGroup new.
+TRRegisterDependencies >> initializeWithPre: preDependencyGroup post: postDependencyGroup [
+	pre := preDependencyGroup.
+	post := postDependencyGroup
 ]
 
 { #category : #testing }
@@ -100,4 +113,11 @@ TRRegisterDependencies >> post [
 { #category : #accessing }
 TRRegisterDependencies >> pre [
 	^ pre
+]
+
+{ #category : #utilities }
+TRRegisterDependencies >> replaceVirtualRegistersUsing: replacementMap [
+	^ self class
+		pre: (pre replaceVirtualRegistersUsing: replacementMap)
+		post: (post replaceVirtualRegistersUsing: replacementMap)
 ]

--- a/src/Tinyrossa/TRRegisterDependencyGroup.class.st
+++ b/src/Tinyrossa/TRRegisterDependencyGroup.class.st
@@ -34,3 +34,18 @@ TRRegisterDependencyGroup >> addTrashed: rReg [
 
 	self add: (TRRegisterDependency virtual: nil real: rReg).
 ]
+
+{ #category : #utilities }
+TRRegisterDependencyGroup >> replaceVirtualRegistersUsing: replacementMap [
+	(self anySatisfy: [:dep | dep vreg notNil and:[replacementMap includesKey: dep vreg name] ]) ifTrue: [
+		^ self collect: [ :dep |
+			(dep vreg notNil and:[replacementMap includesKey: dep vreg name]) ifTrue: [
+				TRRegisterDependency virtual: (replacementMap at: dep vreg name) real: dep rreg
+			] ifFalse: [
+				dep
+			].
+		].
+	] ifFalse: [
+		^ self
+	].
+]

--- a/src/Tinyrossa/TRReverseLinearScanRegisterAllocator.class.st
+++ b/src/Tinyrossa/TRReverseLinearScanRegisterAllocator.class.st
@@ -469,14 +469,14 @@ TRReverseLinearScanRegisterAllocator >> splitRegister: interval at: insnIndex [
 	"Create new interval representing the first part of original interval
 	 up to current position. While walking definitions and uses,
 	 update instructions to use new virtual registers"
-	regmap := Dictionary new at: interval register name put: before register name; yourself.
+	regmap := Dictionary new at: interval register name put: before register; yourself.
 	interval defdDo: [ :i |
 		before defdAt:i.
-		instructions at: i put: ((instructions at: i) inEnvironment: regmap).
+		instructions at: i put: ((instructions at: i) replaceVirtualRegistersUsing: regmap).
 	].
 	interval usedDo: [:i | i <= insnIndex ifTrue: [
 		before usedAt:i.
-		instructions at: i put: ((instructions at: i) inEnvironment: regmap).
+		instructions at: i put: ((instructions at: i) replaceVirtualRegistersUsing: regmap).
 	]].
 
 	"Allocate spill slot for being-splitted `interval`. Insert reload


### PR DESCRIPTION
This commit fixes horrible bug in RSLRA causing arguments not being moved to argument registers when the original interval was split.

This was because when updating instructions to use newly create v-reg for just-split interval, register dependencies were not updated, referring to original v-reg.

To fix this problem, this commit introduces mew method - `#replaceVirtualRegistersUsing:` - to perform v-reg replacements which updates not only register used by the instruction, but also those referred-to in dependencies (and possibly other Tinyrossa-specific metadata attached to an instruction).