### PR TITLE
Add support for static symbols and GOT

### DIFF
--- a/src/Tinyrossa-POWER/TRPPC64Linux.class.st
+++ b/src/Tinyrossa-POWER/TRPPC64Linux.class.st
@@ -9,6 +9,13 @@ TRPPC64Linux >> codeGeneratorClass [
 	^ TRPPC64CodeGenerator
 ]
 
+{ #category : #queries }
+TRPPC64Linux >> endian [
+
+	"FIXME: allow for BE PPC"
+	^ Endian little
+]
+
 { #category : #accessing }
 TRPPC64Linux >> name [
 	^ 'powerpc64le-linux'

--- a/src/Tinyrossa-POWER/TRPPC64Linux.class.st
+++ b/src/Tinyrossa-POWER/TRPPC64Linux.class.st
@@ -21,6 +21,11 @@ TRPPC64Linux >> name [
 	^ 'powerpc64le-linux'
 ]
 
+{ #category : #'queries - private' }
+TRPPC64Linux >> sizeInBytesOfAddress [
+	^ 8
+]
+
 { #category : #'accessing - config - compilation' }
 TRPPC64Linux >> systemLinkageClass [
 	^ TRPPC64PSABILinkage

--- a/src/Tinyrossa-RISCV/TRRV64GCodeEvaluator.class.st
+++ b/src/Tinyrossa-RISCV/TRRV64GCodeEvaluator.class.st
@@ -76,24 +76,37 @@ TRRV64GCodeEvaluator >> commonDiv: node [
 TRRV64GCodeEvaluator >> commonLoad: node [
 	"Handles aload, lload, iload, sload & bload"  
 
-	| dstReg offset type |
+	| dstReg baseReg offset type |
 
-	offset := (AcDSLSymbol value: node symbol name).
+	node symbol isTRStaticSymbol ifTrue: [
+		| l0 |
+
+		baseReg := codegen allocateRegister.
+		l0 := codegen allocateLabel.
+
+		generate label: l0.
+		generate auipc: baseReg, (R_RISCV_GOT_HI20 % node symbol).
+		generate ld:    baseReg, (baseReg + (R_RISCV_PCREL_LO12_I % l0)).
+		offset := 0.
+	] ifFalse: [
+		baseReg := sp.
+		offset := node symbol.
+	].
 	dstReg := codegen allocateRegister.
 
 	type := node type.
 	(type == Address or:[type == Int64]) ifTrue:[
 		generate
-			ld: dstReg, (sp + offset).
+			ld: dstReg, (baseReg + offset).
 	] ifFalse:[ type == Int32 ifTrue:[
 		generate
-			lw: dstReg, (sp + offset).             
+			lw: dstReg, (baseReg + offset).
 	] ifFalse:[ type == Int16 ifTrue:[
 		generate
-			lh: dstReg, (sp + offset).             
+			lh: dstReg, (baseReg + offset).
 	] ifFalse:[ type == Int8 ifTrue:[
 		generate
-			lb: dstReg, (sp + offset).             
+			lb: dstReg, (baseReg + offset).
 	]]]].
 
 	^dstReg.
@@ -232,24 +245,37 @@ TRRV64GCodeEvaluator >> commonShr: node [
 TRRV64GCodeEvaluator >> commonStore: node [
 	"Handles astore, lstore, istore, sstore & bstore"  
 
-	| srcReg offset type |
+	| srcReg baseReg offset type |
 
-	offset := (AcDSLSymbol value: node symbol name).
 	srcReg := self evaluate: node child1.
+	node symbol isTRStaticSymbol ifTrue: [
+		| l0 |
+
+		baseReg := codegen allocateRegister.
+		l0 := codegen allocateLabel.
+
+		generate label: l0.
+		generate auipc: baseReg, (R_RISCV_GOT_HI20 % node symbol).
+		generate ld:    baseReg, (baseReg + (R_RISCV_PCREL_LO12_I % l0)).
+		offset := 0.
+	] ifFalse: [
+		baseReg := sp.
+		offset := node symbol name.
+	].
 
 	type := node type.
 	(type == Address or:[type == Int64]) ifTrue:[
 		generate
-			sd: srcReg, (sp + offset).
+			sd: srcReg, (baseReg + offset).
 	] ifFalse:[ type == Int32 ifTrue:[
 		generate
-			sw: srcReg, (sp + offset).             
+			sw: srcReg, (baseReg + offset).
 	] ifFalse:[ type == Int16 ifTrue:[
 		generate
-			sh: srcReg, (sp + offset).             
+			sh: srcReg, (baseReg + offset).
 	] ifFalse:[ type == Int8 ifTrue:[
 		generate
-			sb: srcReg, (sp + offset).             
+			sb: srcReg, (baseReg + offset).
 	]]]].
 
 	^nil.

--- a/src/Tinyrossa-RISCV/TRRV64GCodeEvaluator.class.st
+++ b/src/Tinyrossa-RISCV/TRRV64GCodeEvaluator.class.st
@@ -751,6 +751,27 @@ TRRV64GCodeEvaluator >> evaluate_lmul: node [
 ]
 
 { #category : #evaluation }
+TRRV64GCodeEvaluator >> evaluate_loadaddr: node [
+	| dstReg |
+
+	dstReg := codegen allocateRegister.
+
+	node symbol isTRStaticSymbol ifTrue: [
+		| l0 |
+
+		l0 := codegen allocateLabel.
+
+		generate label: l0.
+		generate auipc: dstReg, (R_RISCV_GOT_HI20 % node symbol).
+		generate ld:    dstReg, (dstReg + (R_RISCV_PCREL_LO12_I % l0)).
+	] ifFalse: [
+		generate addi:  dstReg, sp, node symbol.
+	].
+
+	^ dstReg
+]
+
+{ #category : #evaluation }
 TRRV64GCodeEvaluator >> evaluate_lor: node [
 	^self commonBin: node opcodeR: 'or' opcodeI: 'ori'
 ]

--- a/src/Tinyrossa-RISCV/TRRV64GCodeEvaluator.class.st
+++ b/src/Tinyrossa-RISCV/TRRV64GCodeEvaluator.class.st
@@ -166,7 +166,7 @@ TRRV64GCodeEvaluator >> commonShl: node [
 	
 	| width child1 child2 src1Reg src2Reg dstReg |
 	
-	width := node type sizeInBytes * 8.
+	width := (self target sizeInBytesOf: node type) * 8.
 	
 	child1 := node child1.
 	child2 := node child2.
@@ -178,13 +178,13 @@ TRRV64GCodeEvaluator >> commonShl: node [
 		
 		shamt := child2 constant bitAnd: width - 1.
 		shamt == 0 ifTrue:[
-			dstReg := src1Reg.	
+			dstReg := src1Reg.
 		] ifFalse: [
 			dstReg := self codegen allocateRegister.
 			generate slli: dstReg, src1Reg, shamt.
 		].
-	] ifFalse:[	
-		src2Reg := self evaluate: child2.		
+	] ifFalse:[
+		src2Reg := self evaluate: child2.
 		dstReg := self codegen allocateRegister.
 		node type == Int64 ifTrue:[
 			generate sll: dstReg, src1Reg , src2Reg 
@@ -192,7 +192,6 @@ TRRV64GCodeEvaluator >> commonShl: node [
 	].
 
 	^dstReg
-
 ]
 
 { #category : #'evaluation-helpers' }
@@ -201,7 +200,7 @@ TRRV64GCodeEvaluator >> commonShr: node [
 	
 	| width child1 child2 src1Reg src2Reg dstReg |
 	
-	width := node type sizeInBytes * 8.
+	width := (self target sizeInBytesOf: node type) * 8.
 	
 	child1 := node child1.
 	child2 := node child2.
@@ -213,13 +212,13 @@ TRRV64GCodeEvaluator >> commonShr: node [
 		
 		shamt := child2 constant bitAnd: width - 1.
 		shamt == 0 ifTrue:[
-			dstReg := src1Reg.	
+			dstReg := src1Reg.
 		] ifFalse: [
 			dstReg := self codegen allocateRegister.
 			generate srai: dstReg, src1Reg, shamt.
 		].
-	] ifFalse:[	
-		src2Reg := self evaluate: child2.		
+	] ifFalse:[
+		src2Reg := self evaluate: child2.
 		dstReg := self codegen allocateRegister.
 		node type == Int64 ifTrue:[
 			generate sra: dstReg, src1Reg , src2Reg 
@@ -227,7 +226,6 @@ TRRV64GCodeEvaluator >> commonShr: node [
 	].
 
 	^dstReg
-
 ]
 
 { #category : #'evaluation-helpers' }

--- a/src/Tinyrossa-RISCV/TRRV64GLinux.class.st
+++ b/src/Tinyrossa-RISCV/TRRV64GLinux.class.st
@@ -9,6 +9,12 @@ TRRV64GLinux >> codeGeneratorClass [
 	^ TRRV64GCodeGenerator
 ]
 
+{ #category : #queries }
+TRRV64GLinux >> endian [
+	"FIXME: allow for BE RISC-V, though this is non-standard (but possible)"
+	^ Endian little
+]
+
 { #category : #accessing }
 TRRV64GLinux >> name [
 	^ 'riscv64-linux'

--- a/src/Tinyrossa-RISCV/TRRV64GLinux.class.st
+++ b/src/Tinyrossa-RISCV/TRRV64GLinux.class.st
@@ -20,6 +20,11 @@ TRRV64GLinux >> name [
 	^ 'riscv64-linux'
 ]
 
+{ #category : #'queries - private' }
+TRRV64GLinux >> sizeInBytesOfAddress [
+	^ 8
+]
+
 { #category : #'accessing - config - compilation' }
 TRRV64GLinux >> systemLinkageClass [
 	^ TRRV64GPSABILinkage

--- a/src/Tinyrossa-RISCV/TRRV64GPSABILinkage.class.st
+++ b/src/Tinyrossa-RISCV/TRRV64GPSABILinkage.class.st
@@ -98,39 +98,29 @@ TRRV64GPSABILinkage >> generateCall: node [
 
 		addrReg := codegen evaluator evaluate: node child1.
 		call := generate jalr: ra, addrReg, 0.
+		call dependencies: deps.
 	] ifFalse: [
 		"If the call a recursive call..."
-		node symbol == codegen compilation functionSymbol ifTrue: [ 
-			"...then generate 'jal ra, <function>'..."
-			call := generate jal: ra, node symbol.
+		node symbol = codegen compilation functionSymbol ifTrue: [
+			"...then use simple `jal`, hoping offset would fit into 20 bits..."
+			call := generate jal: ra, node symbol .
+			call dependencies: deps.
 		] ifFalse: [
-			"...otherwise..."
-			codegen compilation isAOT ifTrue: [ 
-				"
-				In AOT mode we generate call and let the (runtime) linker 
-				to properly relocate it.
-				"
-				call := generate call: node symbol
-			] ifFalse: [ 
-				"
-				In JIT mode we load address directly into 'ra' 
-				(as opposite to allocating new v-register as in indirect case
-				above) because will be clobbered anyways by jalr storing return 
-				address. This lowers the pressure on RA.
+			"...otherwise use auipc + jalr pair with relocations.
 
-				Also note that rather than this, we should generate a trampoline
-				and call calle through it. Or relative jal if it's close enough. 
-				That's left as future work.
-				"
-				self assert: node symbol address notNil description: 'No address set for function symbol'.
+			We load address directly into 'ra' (as opposite to allocating
+			new v-register as in indirect case above) because will be clobbered
+			anyways by jalr storing return address. This lowers the pressure on RA."
 
-				codegen loadConstant64: node symbol address into: ra.
-				call := generate jalr: ra, ra, 0.
-			].
+			| auipc |
+
+			auipc := generate auipc: ra, (R_RISCV_CALL_PLT % node symbol).
+			auipc dependencies: (TRRegisterDependencies pre: deps pre).
+
+			call := generate jalr: ra, ra, 0.
+			call dependencies: (TRRegisterDependencies post: deps post)
 		].
 	].
-	call dependencies: deps.
-
 
 	"Note that link register has been overwritten"
 	codegen linkRegisterKilled: true.
@@ -140,7 +130,7 @@ TRRV64GPSABILinkage >> generateCall: node [
 		retVreg := nil.
 	] ifFalse:[
 		retVreg := codegen allocateRegister.
-		deps post addDependency: retVreg on: a0.
+		call dependencies post addDependency: retVreg on: a0.
 	].
 
 	^ retVreg

--- a/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
@@ -254,6 +254,53 @@ TRCompilationTestCase >> test03_lconst [
 ]
 
 { #category : #tests }
+TRCompilationTestCase >> test04_call_resolved [
+	| comp1 bldr1 comp2 bldr2 |
+
+	self target name = 'powerpc64le-linux' ifTrue: [
+		self skip: 'Skipped since calls are not implemented for POWER (see issue #45)'.
+	].
+
+	" ### CALLEE ### "
+	comp1 := TRCompilation forConfig: compilation config.
+	bldr1 := comp1 builder.
+	bldr1 defineName: 'callee' type: Int32.
+	bldr1 defineParameter: 'x' type: Int32.
+	bldr1 ireturn:
+		{ bldr1 iadd:
+			{ bldr1 iload: 'x'.
+			  bldr1 iconst: 1 } }.
+	comp1 optimize.
+	comp1 compile.
+
+	" ### CALLER ### "
+	comp2 := TRCompilation forConfig: compilation config.
+	bldr2 := comp2 builder.
+	bldr2 defineName: 'caller' type: Int32.
+	bldr2 defineParameter: 'x' type: Int32.
+	bldr2 defineFunction: 'callee' type: Int32.
+	bldr2 ireturn:
+		{ bldr2 iadd:
+			{ bldr2 iload: 'x'.
+			  bldr2 icall: { bldr2 iload: 'x' . 'callee' } } }.
+	comp2 optimize.
+	comp2 compile.
+
+	" ### ######### ### "
+
+	shell inject: comp1.
+	shell inject: comp2.
+
+	self assert: (shell invoke: comp2 functionSymbol with: { 10 } types: { Int32 })
+		 equals: 21
+
+	"
+	TRRV64GCompilationTests debug: #test03_lconst_n
+	TRPPC64CompilationTests debug: #test03_lconst_n
+	"
+]
+
+{ #category : #tests }
 TRCompilationTestCase >> test06_iadd_discarding_value [
 	| x builder |
 

--- a/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
@@ -306,9 +306,15 @@ TRCompilationTestCase >> test05_increment_static_symbol_b [
 	This is pretty much same as #test_example18_increment_static_symbol
 	but we add counter symbol after the function itself.
 
+	Moreover it inserts static symbol into different sections
+	to test access via GOT.
+
 	This, together with test_example18_increment_static_symbol tests
-	that it does not matter in what order we link objects / define symbols.
+	that it does not matter in what order we link objects / define symbols
+	and that they can be located anywhere in address space.
 	"
+
+	<parameter: #section values: #(nzone heap1 heap2)>
 
 	| ctr asm |
 
@@ -329,7 +335,7 @@ TRCompilationTestCase >> test05_increment_static_symbol_b [
 	asm globl: ctr.
 	asm label: ctr.
 	asm int32: 42.
-	shell nzone add: asm object.
+	(shell perform: (testParameters at: #section)) add: asm object.
 
 	"Invoke function and test"
 	self assert: (shell invoke: compilation functionSymbol with: { } types: { })equals: 43.

--- a/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
@@ -301,6 +301,41 @@ TRCompilationTestCase >> test04_call_resolved [
 ]
 
 { #category : #tests }
+TRCompilationTestCase >> test05_increment_static_symbol_b [
+	"
+	This is pretty much same as #test_example18_increment_static_symbol
+	but we add counter symbol after the function itself.
+
+	This, together with test_example18_increment_static_symbol tests
+	that it does not matter in what order we link objects / define symbols.
+	"
+
+	| ctr asm |
+
+	self target name = 'powerpc64le-linux' ifTrue: [
+		self skip: 'Skipped since Xload/Xstore evaluator does not support statics for POWER (see issue #52)'.
+	].
+
+	"Compile function"
+	TRCompilationExamples new
+		compilation: compilation;
+		example18_increment_static_symbol.
+
+	shell inject: compilation.
+
+	"Create static variable `counter`"
+	ctr := TRStaticSymbol name: 'counter' type: Int32.
+	asm := AcDSLRV64GAssembler new.
+	asm globl: ctr.
+	asm label: ctr.
+	asm int32: 42.
+	shell nzone add: asm object.
+
+	"Invoke function and test"
+	self assert: (shell invoke: compilation functionSymbol with: { } types: { })equals: 43.
+]
+
+{ #category : #tests }
 TRCompilationTestCase >> test06_iadd_discarding_value [
 	| x builder |
 
@@ -459,5 +494,33 @@ TRCompilationTestCase >> test_example16_factorial_i_with_overflow [
 	"
 	13 factorial > 0x7FFFFFFF
 	22 factorial > 0x7FFFFFFFFFFFFFFF
+	"
+]
+
+{ #category : #'tests - examples' }
+TRCompilationTestCase >> test_example18_increment_static_symbol [
+	| ctr asm |
+
+	self target name = 'powerpc64le-linux' ifTrue: [
+		self skip: 'Skipped since Xload/Xstore evaluator does not support statics for POWER (see issue #52)'.
+	].
+
+	"Create and add static counter"
+	ctr := TRStaticSymbol name: 'counter' type: Int32.
+	asm := AcDSLRV64GAssembler new.
+	asm globl: ctr.
+	asm label: ctr.
+	asm int32: 42.
+
+	shell nzone add: asm object.
+
+	TRCompilationExamples new
+		compilation: compilation;
+		example18_increment_static_symbol.
+	self assert: (shell inject: compilation andInvokeWith: { })equals: 43.
+
+
+	"
+	shell debugger cli
 	"
 ]

--- a/src/Tinyrossa-Tests/TRILTestTarget.class.st
+++ b/src/Tinyrossa-Tests/TRILTestTarget.class.st
@@ -19,6 +19,11 @@ TRILTestTarget >> name [
 	^ '<triltests>'
 ]
 
+{ #category : #'queries - private' }
+TRILTestTarget >> sizeInBytesOfAddress [
+	^ self shouldNotImplement
+]
+
 { #category : #'accessing - config - compilation' }
 TRILTestTarget >> systemLinkageClass [
 	^ TRILTestLinkage

--- a/src/Tinyrossa-Tests/TRILTestTarget.class.st
+++ b/src/Tinyrossa-Tests/TRILTestTarget.class.st
@@ -9,6 +9,11 @@ TRILTestTarget >> codeGeneratorClass [
 	^ TRILTestCodeGenerator
 ]
 
+{ #category : #queries }
+TRILTestTarget >> endian [
+	^ self shouldNotImplement
+]
+
 { #category : #accessing }
 TRILTestTarget >> name [
 	^ '<triltests>'

--- a/src/Tinyrossa/BigEndian.extension.st
+++ b/src/Tinyrossa/BigEndian.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #BigEndian }
+
+{ #category : #'*Tinyrossa' }
+BigEndian >> isBig [
+	^ true
+]

--- a/src/Tinyrossa/Endian.extension.st
+++ b/src/Tinyrossa/Endian.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Endian }
+
+{ #category : #'*Tinyrossa' }
+Endian >> isBig [
+	^ false
+]
+
+{ #category : #'*Tinyrossa' }
+Endian >> isLittle [
+	^ false
+]

--- a/src/Tinyrossa/LittleEndian.extension.st
+++ b/src/Tinyrossa/LittleEndian.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #LittleEndian }
+
+{ #category : #'*Tinyrossa' }
+LittleEndian >> isLittle [
+	^ true
+]

--- a/src/Tinyrossa/Object.extension.st
+++ b/src/Tinyrossa/Object.extension.st
@@ -51,6 +51,11 @@ Object >> isTRSourceLocation [
 ]
 
 { #category : #'*Tinyrossa' }
+Object >> isTRStaticSymbol [
+	^ false
+]
+
+{ #category : #'*Tinyrossa' }
 Object >> isTRSymbol [
 	"return false here; to be redefined in subclass(es)"
 

--- a/src/Tinyrossa/TRCodeCache.class.st
+++ b/src/Tinyrossa/TRCodeCache.class.st
@@ -70,6 +70,7 @@ TRCodeCache >> add: codeObj [
 	codeObj exports keysAndValuesDo: [ :symbol :addr |
 		| symbolToAdd |
 
+		self assert: symbol isTRStaticSymbol.
 		self assert:(symbols keys contains: [:each | each name = symbol name]) not.
 		self assert:(addr between: base and: base + size - 1).
 

--- a/src/Tinyrossa/TRCodeCache.class.st
+++ b/src/Tinyrossa/TRCodeCache.class.st
@@ -31,13 +31,18 @@ Class {
 		'manager',
 		'base',
 		'size',
+		'sizeOfGOTentry',
 		'memory',
 		'codeAllocPtr',
+		'goteAllocPtr',
 		'linker',
 		'exports',
 		'symbols',
 		'relocations',
 		'pending'
+	],
+	#pools : [
+		'TRDataTypes'
 	],
 	#category : #'Tinyrossa-Runtime-Code Cache'
 }
@@ -145,11 +150,22 @@ TRCodeCache >> addSymbol: aTRStaticSymbol [
 TRCodeCache >> allocCode: codeSize [
 	| codeStart |
 
-	self assert: (codeAllocPtr + codeSize) < (base + size).
+	self assert: (codeAllocPtr + codeSize) < goteAllocPtr.
 
 	codeStart := codeAllocPtr.
 	codeAllocPtr := codeAllocPtr + codeSize.
 	^ codeStart.
+]
+
+{ #category : #private }
+TRCodeCache >> allocGOTentry [
+	| addr |
+
+	self assert: codeAllocPtr < (goteAllocPtr - sizeOfGOTentry).
+
+	addr := goteAllocPtr.
+	goteAllocPtr := goteAllocPtr - sizeOfGOTentry.
+	^ addr.
 ]
 
 { #category : #accessing }
@@ -172,6 +188,31 @@ TRCodeCache >> exports [
 		exportMap at: symbol put: (symbols at: symbol)
 	].
 	^ exportMap
+]
+
+{ #category : #private }
+TRCodeCache >> getGOTentryFor: aTRStaticSymbol [
+	| entry |
+
+	self assert: aTRStaticSymbol isTRStaticSymbol.
+	self assert:(symbols includesKey: aTRStaticSymbol).
+
+	entry := aTRStaticSymbol got.
+	^ symbols elementAt: entry ifAbsent: [
+		entry setAddress: self allocGOTentry.
+
+		sizeOfGOTentry == 4 ifTrue: [
+			memory unsignedLongAt: entry address put: (symbols at: aTRStaticSymbol) bigEndian: runtime target endian isBig.
+		] ifFalse: [
+		sizeOfGOTentry == 8 ifTrue: [
+			memory unsignedLongLongAt: entry address put: (symbols at: aTRStaticSymbol) bigEndian: runtime target endian isBig.
+		] ifFalse: [
+			self assert: false description: 'Unsupported GOT entry size'
+		]].
+
+		symbols at: entry put: entry address.
+		entry.
+	]
 ]
 
 { #category : #inspecting }
@@ -240,9 +281,11 @@ TRCodeCache >> initializeWithRuntime: runtimeArg base: baseArg size: sizeArg mem
 	runtime := runtimeArg.
 	base := baseArg.
 	size := sizeArg.
+	sizeOfGOTentry := runtime target sizeInBytesOf: Address.
 	memory := memoryArg.
 
 	codeAllocPtr := base.
+	goteAllocPtr := base + size - sizeOfGOTentry.
 
 	manager := nil.
 	exports := Set new.
@@ -324,6 +367,11 @@ TRCodeCache >> link [
 				pending remove: reloc.
 			] on: AcRelocationSymbolUnresolved do: [:ex |
 				"Ignore, might get resolved later."
+			] on: AcRelocationRequestGOTEntry do: [:req |
+				| entry |
+
+				entry := self getGOTentryFor: req symbol.
+				req resume: entry -> entry address.
 			].
 		].
 	].

--- a/src/Tinyrossa/TRCodeEvaluator.class.st
+++ b/src/Tinyrossa/TRCodeEvaluator.class.st
@@ -170,3 +170,8 @@ TRCodeEvaluator >> initializeWithCodeGenerator: aTRCodeGenerator [
 	codegen := aTRCodeGenerator.
 	generate := codegen assembler.
 ]
+
+{ #category : #accessing }
+TRCodeEvaluator >> target [
+	^ self codegen target
+]

--- a/src/Tinyrossa/TRCodeGenerator.class.st
+++ b/src/Tinyrossa/TRCodeGenerator.class.st
@@ -13,6 +13,11 @@ Class {
 	#category : #'Tinyrossa-Codegen'
 }
 
+{ #category : #labels }
+TRCodeGenerator >> allocateLabel [
+	^ compilation symbolManager defineLabel
+]
+
 { #category : #registers }
 TRCodeGenerator >> allocateRegister [
 	^ self allocateRegister: GPR

--- a/src/Tinyrossa/TRCodeGeneratorBase.class.st
+++ b/src/Tinyrossa/TRCodeGeneratorBase.class.st
@@ -45,3 +45,8 @@ TRCodeGeneratorBase >> evaluatorClass [
 TRCodeGeneratorBase >> initializeWithCompilation: aTRCompilation [
 	compilation := aTRCompilation.
 ]
+
+{ #category : #accessing }
+TRCodeGeneratorBase >> target [
+	^ compilation target
+]

--- a/src/Tinyrossa/TRCompilation.class.st
+++ b/src/Tinyrossa/TRCompilation.class.st
@@ -159,6 +159,11 @@ TRCompilation >> symbolManager [
 	^ symbolManager
 ]
 
+{ #category : #accessing }
+TRCompilation >> target [
+	^ config target
+]
+
 { #category : #verification }
 TRCompilation >> verify [
 	"Make sure the current TRIL is well-formed. No-op if it is,

--- a/src/Tinyrossa/TRCompilationExamples.class.st
+++ b/src/Tinyrossa/TRCompilationExamples.class.st
@@ -701,6 +701,35 @@ TRCompilationExamples >> example17_call_external_function_in_aot_mode [
 	compilation codeBuffer. "Only convenience inspection."
 ]
 
+{ #category : #examples }
+TRCompilationExamples >> example18_increment_static_symbol [
+	| builder |
+
+	builder := compilation builder.
+	builder defineName: 'increment_static_symbol' type: Int32.
+	builder defineAutomatic: 'temp' type: Int32.
+	builder defineStatic: 'counter' type: Int32.
+
+	builder istore: {
+		builder iadd:{
+			builder iload: 'counter'.
+			builder iconst: 1 }.
+		"->" 'temp' }.
+
+	builder istore: {
+		builder iload: 'temp'.
+		"->" 'counter' }.
+
+	builder ireturn: {
+		builder iload:'temp' }.
+
+	compilation optimize.
+
+	compilation compile.
+
+	compilation codeBuffer bytes. "Only convenience inspection."
+]
+
 { #category : #running }
 TRCompilationExamples >> setUp [
 	super setUp.

--- a/src/Tinyrossa/TRDataType.class.st
+++ b/src/Tinyrossa/TRDataType.class.st
@@ -126,7 +126,20 @@ TRDataType >> printOn:aStream [
 
 { #category : #queries }
 TRDataType >> sizeInBytes [
-	^self subclassResponsibility 
+	"DO NOT USE!
+
+	 While it would be very conventient to implement such method,
+	 it is not really possible. Size of type Address is not fixed,
+	 it is 4 on 32bit and 8 on 64bit systems. So, one has to use
+
+		 compilation target sizeInBytesOf: type
+
+	 instead.
+
+	 This method (and this comment) exists warn future myself
+	 from the temptation to implement it again.
+	"
+	^self shouldNotImplement "Use #sizeInBytesOf: instead"
 ]
 
 { #category : #queries }

--- a/src/Tinyrossa/TRDataTypeDouble.class.st
+++ b/src/Tinyrossa/TRDataTypeDouble.class.st
@@ -17,11 +17,6 @@ TRDataTypeDouble >> name [
    ^ 'Double'
 ]
 
-{ #category : #queries }
-TRDataTypeDouble >> sizeInBytes [
-	^8
-]
-
 { #category : #validation }
 TRDataTypeDouble >> validateConstant: aNumber [
    self assert: aNumber isFloat

--- a/src/Tinyrossa/TRDataTypeFloat.class.st
+++ b/src/Tinyrossa/TRDataTypeFloat.class.st
@@ -17,11 +17,6 @@ TRDataTypeFloat >> name [
 	^ 'Float'
 ]
 
-{ #category : #queries }
-TRDataTypeFloat >> sizeInBytes [
-	^4
-]
-
 { #category : #validation }
 TRDataTypeFloat >> validateConstant: aNumber [
 	self assert: aNumber isFloat

--- a/src/Tinyrossa/TRDataTypeInt16.class.st
+++ b/src/Tinyrossa/TRDataTypeInt16.class.st
@@ -17,11 +17,6 @@ TRDataTypeInt16 >> name [
 	^ 'Int16'
 ]
 
-{ #category : #queries }
-TRDataTypeInt16 >> sizeInBytes [
-	^2
-]
-
 { #category : #validation }
 TRDataTypeInt16 >> validateConstant: aNumber [
 	self assert: (aNumber between: -16r8000 and: 16r7FFF) description: 'Invalid constant'

--- a/src/Tinyrossa/TRDataTypeInt32.class.st
+++ b/src/Tinyrossa/TRDataTypeInt32.class.st
@@ -17,11 +17,6 @@ TRDataTypeInt32 >> name [
    ^ 'Int32'
 ]
 
-{ #category : #queries }
-TRDataTypeInt32 >> sizeInBytes [
-	^4
-]
-
 { #category : #validation }
 TRDataTypeInt32 >> validateConstant: aNumber [
 	self assert: (aNumber between: -16r80000000 and: 16r7FFFFFFF) description: 'Invalid constant'

--- a/src/Tinyrossa/TRDataTypeInt64.class.st
+++ b/src/Tinyrossa/TRDataTypeInt64.class.st
@@ -17,11 +17,6 @@ TRDataTypeInt64 >> name [
 	^ 'Int64'
 ]
 
-{ #category : #queries }
-TRDataTypeInt64 >> sizeInBytes [
-	^8
-]
-
 { #category : #validation }
 TRDataTypeInt64 >> validateConstant: aNumber [
 	self assert: (aNumber between: -16r8000000000000000 and: 16r7FFFFFFFFFFFFFFF) description: 'Invalid constant'

--- a/src/Tinyrossa/TRDataTypeInt8.class.st
+++ b/src/Tinyrossa/TRDataTypeInt8.class.st
@@ -17,11 +17,6 @@ TRDataTypeInt8 >> name [
    ^ 'Int8'
 ]
 
-{ #category : #queries }
-TRDataTypeInt8 >> sizeInBytes [
-	^1
-]
-
 { #category : #validation }
 TRDataTypeInt8 >> validateConstant: aNumber [
 	self assert: (aNumber between: -16r80 and: 16r7F) description: 'Invalid constant'

--- a/src/Tinyrossa/TRDataTypeUnspecified.class.st
+++ b/src/Tinyrossa/TRDataTypeUnspecified.class.st
@@ -19,11 +19,6 @@ TRDataTypeUnspecified >> name [
 	^ 'Unspecified'
 ]
 
-{ #category : #queries }
-TRDataTypeUnspecified >> sizeInBytes [
-	^self shouldNotImplement  
-]
-
 { #category : #validation }
 TRDataTypeUnspecified >> validateConstant: aNumber [
 	^ self shouldNotImplement

--- a/src/Tinyrossa/TRDataTypeVoid.class.st
+++ b/src/Tinyrossa/TRDataTypeVoid.class.st
@@ -14,11 +14,6 @@ TRDataTypeVoid >> name [
 	^ 'Void'
 ]
 
-{ #category : #queries }
-TRDataTypeVoid >> sizeInBytes [
-	^self shouldNotImplement 
-]
-
 { #category : #validation }
 TRDataTypeVoid >> validateConstant: aNumber [
    self assert: false

--- a/src/Tinyrossa/TRFunctionSymbol.class.st
+++ b/src/Tinyrossa/TRFunctionSymbol.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : #TRFunctionSymbol,
-	#superclass : #TRSymbol,
+	#superclass : #TRStaticSymbol,
 	#instVars : [
-		'linkageClass',
-		'address'
+		'linkageClass'
 	],
 	#pools : [
 		'TRIntLimits'
@@ -12,26 +11,18 @@ Class {
 }
 
 { #category : #'instance creation' }
-TRFunctionSymbol class >> name:name type:type linkage: linkageClass [ 
+TRFunctionSymbol class >> name: name type: type [
+	^ self shouldNotImplement "Use #name:type:linkage: instead"
+]
+
+{ #category : #'instance creation' }
+TRFunctionSymbol class >> name:name type:type linkage: linkageClass [
 	^ self basicNew initializeWithName:name type:type linkage: linkageClass
 ]
 
-{ #category : #accessing }
-TRFunctionSymbol >> address [
-	"Return the address of this function or `nil` is address is not
-	 (yet) known."
-	
-	^address
-]
-
-{ #category : #converting }
-TRFunctionSymbol >> asAcDSLOperand [
-	^ AcDSLSymbol value: name
-]
-
-{ #category : #converting }
-TRFunctionSymbol >> asAcDSLOperandList [
-	^ self asAcDSLOperand asAcDSLOperandList
+{ #category : #'instance creation' }
+TRFunctionSymbol class >> new [
+	^ self shouldNotImplement "Use #name:type:linkage: instead"
 ]
 
 { #category : #initialization }
@@ -49,13 +40,4 @@ TRFunctionSymbol >> isTRFunctionSymbol [
 { #category : #'accessing-config' }
 TRFunctionSymbol >> linkageClass [
 	^ linkageClass
-]
-
-{ #category : #initialization }
-TRFunctionSymbol >> setAddress: anInteger [
-	self assert: anInteger isInteger.
-	self assert:(anInteger between: 0 and: 16rFFFFFFFFFFFFFFFF).
-	self assert: address isNil.
-	
-	address := anInteger.
 ]

--- a/src/Tinyrossa/TRILBuilder.class.st
+++ b/src/Tinyrossa/TRILBuilder.class.st
@@ -71,6 +71,11 @@ TRILBuilder >> defineFunction: name type: type linkage: linkage [
 	^ compilation symbolManager defineFunction: name type: type linkage: linkage
 ]
 
+{ #category : #'defining symbols' }
+TRILBuilder >> defineStatic: name type: type [
+	 ^ compilation symbolManager defineStatic: name type: type
+]
+
 { #category : #'building-blocks' }
 TRILBuilder >> fallThroughTo: anILBuilder [
 	self fallThroughToBlock: anILBuilder entry

--- a/src/Tinyrossa/TRLabelSymbol.class.st
+++ b/src/Tinyrossa/TRLabelSymbol.class.st
@@ -20,6 +20,11 @@ TRLabelSymbol >> block [
 	^ block
 ]
 
+{ #category : #conversion }
+TRLabelSymbol >> got [
+	^ self shouldNotImplement
+]
+
 { #category : #initialization }
 TRLabelSymbol >> initializeWithName:nameArg type:typeArg [
 	self assert: typeArg == Void description: 'Type of a label must be void'.

--- a/src/Tinyrossa/TRLabelSymbol.class.st
+++ b/src/Tinyrossa/TRLabelSymbol.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #TRLabelSymbol,
-	#superclass : #TRSymbol,
+	#superclass : #TRStaticSymbol,
 	#instVars : [
 		'block'
 	],
@@ -12,17 +12,7 @@ Class {
 
 { #category : #'instance creation' }
 TRLabelSymbol class >> name: aString [
-	^ self basicNew initializeWithName: aString
-]
-
-{ #category : #converting }
-TRLabelSymbol >> asAcDSLOperand [
-	^ AcDSLSymbol value: name
-]
-
-{ #category : #converting }
-TRLabelSymbol >> asAcDSLOperandList [
-	^ self asAcDSLOperand asAcDSLOperandList
+	^ self name: aString type: Void
 ]
 
 { #category : #accessing }
@@ -31,11 +21,10 @@ TRLabelSymbol >> block [
 ]
 
 { #category : #initialization }
-TRLabelSymbol >> initializeWithName: aString [
-	self assert: aString isString.
-		
-	name := aString.
-	type := Void.
+TRLabelSymbol >> initializeWithName:nameArg type:typeArg [
+	self assert: typeArg == Void description: 'Type of a label must be void'.
+
+	super initializeWithName:nameArg type:typeArg
 ]
 
 { #category : #testing }

--- a/src/Tinyrossa/TRLabelSymbol.class.st
+++ b/src/Tinyrossa/TRLabelSymbol.class.st
@@ -4,13 +4,15 @@ Class {
 	#instVars : [
 		'block'
 	],
+	#pools : [
+		'TRDataTypes'
+	],
 	#category : #'Tinyrossa-IL-Symbols'
 }
 
 { #category : #'instance creation' }
-TRLabelSymbol class >> block: aTRILBlock [
-	^ self basicNew initializeWithBlock: aTRILBlock
-
+TRLabelSymbol class >> name: aString [
+	^ self basicNew initializeWithName: aString
 ]
 
 { #category : #converting }
@@ -29,24 +31,21 @@ TRLabelSymbol >> block [
 ]
 
 { #category : #initialization }
-TRLabelSymbol >> initializeWithBlock: aTRILBlock [
-	self assert: aTRILBlock isTRILBlock.
+TRLabelSymbol >> initializeWithName: aString [
+	self assert: aString isString.
 		
-	aTRILBlock compilation isAOT ifTrue:[	
-		"In AOT mode to generate and object file we use external 
-	 	 assembler (just like GCC) which treats labels prefixed with
-	   '.L' as local (intra-procedural) labels and does not put them
-	   into symbol table. We do the same here:"	
-		name := '.L_' , aTRILBlock name.	
-	] ifFalse: [
-		name := aTRILBlock name.	
-	].
-		
-	type := TRDataType named: 'Void'.
-	block := aTRILBlock.
+	name := aString.
+	type := Void.
 ]
 
 { #category : #testing }
 TRLabelSymbol >> isTRLabelSymbol [
 	^ true
+]
+
+{ #category : #initialization }
+TRLabelSymbol >> setBlock: aTRILBlock [
+	self assert: aTRILBlock isTRILBlock.
+
+	block := aTRILBlock
 ]

--- a/src/Tinyrossa/TRStaticSymbol.class.st
+++ b/src/Tinyrossa/TRStaticSymbol.class.st
@@ -20,6 +20,7 @@ Class {
 		'address'
 	],
 	#pools : [
+		'TRDataTypes',
 		'TRIntLimits'
 	],
 	#category : #'Tinyrossa-IL-Symbols'
@@ -46,6 +47,12 @@ TRStaticSymbol >> address [
 { #category : #converting }
 TRStaticSymbol >> asAcDSLOperand [
 	^ AcDSLSymbol value: name
+]
+
+{ #category : #conversion }
+TRStaticSymbol >> got [
+	"Return the GOT entry for this symbol as another symbol"
+	^ TRStaticSymbol name: name , '@got' type: Address
 ]
 
 { #category : #initialization }

--- a/src/Tinyrossa/TRStaticSymbol.class.st
+++ b/src/Tinyrossa/TRStaticSymbol.class.st
@@ -1,0 +1,69 @@
+"
+Static symbols represent data stored on the heap (as opposed to data
+stored in frame which are represented by `TRRegisterMappedSymbol`s)
+and therefore have a single unique absolute address.
+
+The address however may not be known in advance so code individual code
+generators must always generate proper relocations when accessing static symbols.
+
+Jump labels and functions are special kind of static symbols.
+
+NOTE: The name 'static' may not be best, maybe something like 'global'
+or 'relocatable' would be a better fit, but we choose to stick with
+'static' as it is what Testarossa calls it.
+
+"
+Class {
+	#name : #TRStaticSymbol,
+	#superclass : #TRSymbol,
+	#instVars : [
+		'address'
+	],
+	#pools : [
+		'TRIntLimits'
+	],
+	#category : #'Tinyrossa-IL-Symbols'
+}
+
+{ #category : #'instance creation' }
+TRStaticSymbol class >> name:name type:type [
+	^ self basicNew initializeWithName:name type:type
+]
+
+{ #category : #'instance creation' }
+TRStaticSymbol class >> new [
+	^ self shouldNotImplement "Use #name:type: instead"
+]
+
+{ #category : #accessing }
+TRStaticSymbol >> address [
+	"Return the address of this function or `nil` is address is not
+	 (yet) known."
+
+	^address
+]
+
+{ #category : #converting }
+TRStaticSymbol >> asAcDSLOperand [
+	^ AcDSLSymbol value: name
+]
+
+{ #category : #initialization }
+TRStaticSymbol >> initializeWithName:nameArg type:typeArg [
+	name := nameArg.
+	type := typeArg.
+]
+
+{ #category : #testing }
+TRStaticSymbol >> isTRStaticSymbol [
+	^ true
+]
+
+{ #category : #initialization }
+TRStaticSymbol >> setAddress: anInteger [
+	self assert: anInteger isInteger.
+	self assert:(anInteger between: 0 and: 16rFFFFFFFFFFFFFFFF).
+	self assert: address isNil.
+
+	address := anInteger.
+]

--- a/src/Tinyrossa/TRSymbolManager.class.st
+++ b/src/Tinyrossa/TRSymbolManager.class.st
@@ -72,6 +72,11 @@ TRSymbolManager >> defineParameter: name type: type [
 	^ self define: (self newParameter: name type: type index: index)
 ]
 
+{ #category : #defining }
+TRSymbolManager >> defineStatic: name type: type [
+	^ self define: (self newStatic: name type: type)
+]
+
 { #category : #queries }
 TRSymbolManager >> hasSymbolNamed: aString [ 
 	^ symbols contains: [:symbol | symbol name = aString ]

--- a/src/Tinyrossa/TRSymbolManager.class.st
+++ b/src/Tinyrossa/TRSymbolManager.class.st
@@ -44,16 +44,24 @@ TRSymbolManager >> defineFunction: name type: type linkage: linkageClass [
 ]
 
 { #category : #defining }
-TRSymbolManager >> defineLabel: block [
+TRSymbolManager >> defineLabel [
+	^ self defineLabel: nil
+]
+
+{ #category : #defining }
+TRSymbolManager >> defineLabel: nameOrBlock [
 	| label |
 
-	self assert: block isTRILBlock.
-
-	label := self lookupLabelByBlock: block.
-	label isNil ifTrue: [ 
-		label := self define: (self newLabel: block)
+	nameOrBlock isTRILBlock ifTrue: [
+		label := self lookupLabelByBlock: nameOrBlock.
+		label isNil ifTrue: [
+			label := self defineLabel: nameOrBlock name.
+			label setBlock: nameOrBlock.
+		].
+		self assert: (label instVarNamed:#block) == nameOrBlock.
+		^ label.
 	].
-	^ label
+	^ self define: (self newLabel: nameOrBlock)
 ]
 
 { #category : #defining }
@@ -80,7 +88,7 @@ TRSymbolManager >> lookupLabelByBlock: aTRILBlock [
 	self assert: aTRILBlock isTRILBlock.
 
 	^ symbols 
-		detect: [:symbol | symbol isTRLabelSymbol and:[symbol block == aTRILBlock ] ]
+		detect: [:symbol | symbol isTRLabelSymbol and:[symbol name == aTRILBlock name] ]
 		ifNone: [ nil ]
 ]
 
@@ -126,15 +134,28 @@ TRSymbolManager >> newFunction: name type: type linkage: linkageClass [
 ]
 
 { #category : #creating }
-TRSymbolManager >> newLabel: block [
-	self assert: block isTRILBlock.
+TRSymbolManager >> newLabel: nameOrNil [
+	| name |
 
-	^ TRLabelSymbol block: block
+	name := nameOrNil.
+	name isNil ifTrue: [
+		| index  |
+
+		index := (symbols count: [ :symbol | symbol isTRLabelSymbol ]) + 1.
+		name := '.LL_' , (index printLeftPaddedWith: $0 to: 3 base: 10).
+	].
+
+	^ TRLabelSymbol name: name
 ]
 
 { #category : #creating }
 TRSymbolManager >> newParameter: name type: type index: index [
 	^ TRParameterSymbol name: name type: type index: index
+]
+
+{ #category : #creating }
+TRSymbolManager >> newStatic: name type: type [
+	^ TRStaticSymbol name: name type: type
 ]
 
 { #category : #accessing }

--- a/src/Tinyrossa/TRTarget.class.st
+++ b/src/Tinyrossa/TRTarget.class.st
@@ -12,6 +12,9 @@ Targets are singletons, use `#default` to get singleton instance.
 Class {
 	#name : #TRTarget,
 	#superclass : #Object,
+	#pools : [
+		'TRDataTypes'
+	],
 	#classInstVars : [
 		'default'
 	],
@@ -39,6 +42,29 @@ TRTarget >> endian [
 
 { #category : #accessing }
 TRTarget >> name [
+	^ self subclassResponsibility
+]
+
+{ #category : #queries }
+TRTarget >> sizeInBytesOf: aTRDatyType [
+	"Given a datatype, return it size in memory in bytes."
+
+	aTRDatyType == Int8     ifTrue: [ ^ 1].
+	aTRDatyType == Int16    ifTrue: [ ^ 1].
+	aTRDatyType == Int32    ifTrue: [ ^ 4].
+	aTRDatyType == Int64    ifTrue: [ ^ 8].
+	aTRDatyType == Address  ifTrue: [ ^ self sizeInBytesOfAddress ].
+	aTRDatyType == Float    ifTrue: [ ^ 4].
+	aTRDatyType == Double   ifTrue: [ ^ 8].
+	aTRDatyType == Void     ifTrue: [ ^ 0].
+
+	self error: 'Unsupported datatype'
+]
+
+{ #category : #'queries - private' }
+TRTarget >> sizeInBytesOfAddress [
+	"Return size of address (pointer) in bytes"
+
 	^ self subclassResponsibility
 ]
 

--- a/src/Tinyrossa/TRTarget.class.st
+++ b/src/Tinyrossa/TRTarget.class.st
@@ -31,6 +31,12 @@ TRTarget >> codeGeneratorClass [
 	^ self subclassResponsibility
 ]
 
+{ #category : #queries }
+TRTarget >> endian [
+	"Return endian (either `Endian little` or `Endian big`)"
+	^ self subclassResponsibility
+]
+
 { #category : #accessing }
 TRTarget >> name [
 	^ self subclassResponsibility


### PR DESCRIPTION
This PR adds support for static symbols and for loading/storing into them via GOT. This is implemented by handling `AcRelocationRequestGOTEntry` in `TRCodeCache >> #link`. GOT entries are allocated from the "end" of the code cache.