### PR TITLE
Add new `TRILBuilder >> #for:from:to:by:do:` to build simple for-loop

### DIFF
--- a/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
+++ b/src/Tinyrossa-Tests/TRCompilationTestCase.class.st
@@ -514,6 +514,15 @@ TRCompilationTestCase >> test_example09_signum_2 [
 ]
 
 { #category : #'tests - examples' }
+TRCompilationTestCase >> test_example10_sum_first_n_numbers [
+	TRCompilationExamples new
+		compilation: compilation;
+		example10_sum_first_n_numbers.
+
+	self assert: (shell inject: compilation andInvokeWith: { 10 }) equals: ((0 to: 9) inject: 0 into:[ :s :i | s + i ]).
+]
+
+{ #category : #'tests - examples' }
 TRCompilationTestCase >> test_example15_add_with_overflow_check [
 	self target name = 'powerpc64le-linux' ifTrue: [
 		self skip: 'Skipped since overflowchk evaluator is not implemented for POWER (see issue #44)'.

--- a/src/Tinyrossa/TRCompilationExamples.class.st
+++ b/src/Tinyrossa/TRCompilationExamples.class.st
@@ -536,6 +536,33 @@ TRCompilationExamples >> example09_signum_2 [
 ]
 
 { #category : #examples }
+TRCompilationExamples >> example10_sum_first_n_numbers [
+	| builder  |
+
+	builder := compilation builder.
+	builder defineName: 'sumn' type: Int32.
+	builder defineParameter: 'n' type: Int32.   
+	builder defineAutomatic: 's' type: Int32.   
+	builder defineAutomatic: 'i' type: Int32.   
+	builder istore: { builder iconst: 0 . 's' }.
+	builder for: 'i' from: (builder iconst: 0) to: (builder iload: 'n') by: (builder iconst: 1) do:[ :body |
+		body istore: {
+			body iadd: {
+				body iload: 's'.
+				body iload: 'i'. } .
+			"-->" 's' }.
+	].
+	builder ireturn: { builder iload: 's' }.
+
+
+	compilation optimize.
+
+	compilation compile.
+
+	compilation codeBuffer. "Only convenience inspection."
+]
+
+{ #category : #examples }
 TRCompilationExamples >> example12_call_external_function [
 	| builder |
 

--- a/src/Tinyrossa/TRILBuilder.class.st
+++ b/src/Tinyrossa/TRILBuilder.class.st
@@ -5,6 +5,8 @@ Class {
 		'location'
 	],
 	#pools : [
+		'TRILOpcodeProps1',
+		'TRILOpcodeProps3',
 		'TRILOpcodes'
 	],
 	#category : #'Tinyrossa-IL-Builder'
@@ -104,6 +106,57 @@ TRILBuilder >> file: file line: line [
 { #category : #'building-locations' }
 TRILBuilder >> file: file line: line column: column [
 	self location: (TRSourceLocation file: file line: line column: column)
+]
+
+{ #category : #'building-helpers' }
+TRILBuilder >> for: variableName from: initialValue to: finalValue by: stepValue do: bodyBuilderOrClosure [
+	| variable loadOp storeOp cmpleOp addOp setupBlock condBlock bodyBuilder incrementBlock joinBlock joinLabel |
+
+	self assert: (compilation symbolManager hasSymbolNamed: variableName).
+	variable := compilation symbolManager lookupSymbolByName: variableName. 
+	self assert:(variable type = initialValue type).  
+	self assert:(variable type = finalValue type).
+	self assert:(variable type = stepValue type).
+
+	loadOp := variable type loadOpcode.    
+	storeOp := variable type storeOpcode.
+	cmpleOp := variable type compareOpcodeFor: CompareTrueIfLess.
+	addOp := variable type arithmeticOpcodeFor: Add.
+
+	setupBlock := compilation cfg addBlock.
+	condBlock := compilation cfg addBlock.
+	bodyBuilder := self orphanIfNeeded: bodyBuilderOrClosure.
+	incrementBlock := compilation cfg addBlock.
+	joinBlock := compilation cfg addBlock.
+	joinLabel := compilation symbolManager defineLabel: joinBlock.
+
+	current setSuccessor1: setupBlock.
+
+	setupBlock add: (TRILNode opcode: storeOp symbol: variable children: { initialValue }).
+	setupBlock setSuccessor1: condBlock.
+
+	condBlock add: (TRILNode opcode: cmpleOp reverseBranchOpcode ifCompareOpcode symbol: joinLabel children: {
+							TRILNode opcode: loadOp symbol: variable .
+							finalValue } ).
+	condBlock setSuccessor1: bodyBuilder entry.
+
+	bodyBuilder fallThroughToBlock: incrementBlock.
+
+	incrementBlock add: (TRILNode opcode: storeOp symbol: variable children: { 
+							TRILNode opcode: addOp children: {
+								TRILNode opcode: loadOp symbol: variable .
+								stepValue } } ).
+	incrementBlock setSuccessor1: condBlock.
+
+	current := joinBlock.
+]
+
+{ #category : #'building-helpers' }
+TRILBuilder >> for: variableName from: initialValue to: finalValue do: bodyBuilderOrClosure [
+	| stepValue |
+
+	stepValue := TRILNode opcode: initialValue type constOpcode constant: 1.
+	^ self for: variableName from: initialValue to: finalValue by: stepValue do: bodyBuilderOrClosure
 ]
 
 { #category : #'building-helpers' }

--- a/src/Tinyrossa/TRILOpcode.class.st
+++ b/src/Tinyrossa/TRILOpcode.class.st
@@ -58,6 +58,11 @@ TRILOpcode >> booleanCompareOpcode [
 ]
 
 { #category : #accessing }
+TRILOpcode >> children [
+	^ children
+]
+
+{ #category : #accessing }
 TRILOpcode >> compareFlags [
 	^ props3 bitAnd: CompareTrueIfMask
 ]


### PR DESCRIPTION
This commit adds new API to `TRILBuilder` to build simple for-loop. For now this does not allow building generalized for-loop (like in C for example) but only simple loop counting up or down.