### PR TITLE
Support relocations in AoT mode

### DIFF
--- a/src/Tinyrossa/AcRelocation.extension.st
+++ b/src/Tinyrossa/AcRelocation.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #AcRelocation }
+
+{ #category : #'*Tinyrossa' }
+AcRelocation >> type [
+	"Return type of (ELF) relocation as string, for example 'R_X86_64_GOT32' or
+	'R_RISCV_PCREL_LO12_I'. This is used by TRGASGenerator to output
+	relocations."
+
+	self assert: self class isAbstract not.
+
+	"By convention, relocation classes are named exactly as in respective
+	 specification."
+	^ self class name.
+]

--- a/src/Tinyrossa/TRCompilationExamples.class.st
+++ b/src/Tinyrossa/TRCompilationExamples.class.st
@@ -709,12 +709,13 @@ TRCompilationExamples >> example17_call_external_function_in_aot_mode [
 	| builder |
 
 	builder := compilation builder.
-	builder defineName: 'call_exit' type: Int32.
-	builder defineParameter: 'status' type: Int32.
+	builder defineName: 'main' type: Int32.
+	builder defineParameter: 'argc' type: Int32.
+	builder defineParameter: 'argv' type: Address.
 
 	(builder defineFunction: 'exit' type: Void). 
 
-	builder call: { builder iload: 'status' . 'exit' }.
+	builder call: { builder iload: 'argc' . 'exit' }.
 	builder ireturn: { builder iconst: 0 }.
 
 	compilation config

--- a/src/Tinyrossa/TRGASGenerator.class.st
+++ b/src/Tinyrossa/TRGASGenerator.class.st
@@ -42,7 +42,7 @@ TRGASGenerator >> generateAssemblerFile [
 
 { #category : #'generating output' }
 TRGASGenerator >> generateInstruction: insn on: asm [
-	| location |
+	| location relocation |
 
 	location := insn location.
 	location isTRSourceLocation ifTrue: [ 
@@ -85,6 +85,16 @@ TRGASGenerator >> generateInstruction: insn on: asm [
 			asm lf.
 			bci := location index.
 		].
+	].
+
+	relocation := insn relocation.
+	relocation notNil ifTrue: [
+		self assert: (relocation addend = 0).
+		self assert: (relocation symbol notNil).
+
+		asm nextPutAll: '        '.
+		asm nextPutAll: '.reloc ., '; nextPutAll: relocation type; nextPutAll: ', '; nextPutAll: relocation symbol asString.
+		asm lf.
 	].
 
 	insn isLabelInstruction ifTrue: [ 


### PR DESCRIPTION
This commit add support for relocations in AoT mode. This is done by using GNU assembler's `.reloc` directive [1].

[1]: https://sourceware.org/binutils/docs/as/Reloc.html