### PR TITLE
Add dominance analysis

### DIFF
--- a/src/Tinyrossa-Tests/TRDominanceAnalysisTests.class.st
+++ b/src/Tinyrossa-Tests/TRDominanceAnalysisTests.class.st
@@ -1,0 +1,137 @@
+Class {
+	#name : #TRDominanceAnalysisTests,
+	#superclass : #TRILTestCase,
+	#category : #'Tinyrossa-Tests'
+}
+
+{ #category : #tests }
+TRDominanceAnalysisTests >> test_01 [
+	"Taken from Keith D. Cooper, Linda Torczon: Engineering a Compiler Second Edition,
+	 Chapter 9, Sectuon 9.2.1 Dominance."
+
+	| cfg b0 b1 b2 b3 b4 b5 b6 b7 b8 |
+
+	cfg := compilation cfg.
+	b0 := cfg addBlockNamed: 'B0'.
+	b1 := cfg addBlockNamed: 'B1'.
+	b2 := cfg addBlockNamed: 'B2'.
+	b3 := cfg addBlockNamed: 'B3'.
+	b4 := cfg addBlockNamed: 'B4'.
+	b5 := cfg addBlockNamed: 'B5'.
+	b6 := cfg addBlockNamed: 'B6'.
+	b7 := cfg addBlockNamed: 'B7'.
+	b8 := cfg addBlockNamed: 'B8'.
+
+	b0 setSuccessor1ForTestingOnly: b1.
+
+	b1 setSuccessor1ForTestingOnly: b2.
+	b1 setSuccessor2ForTestingOnly: b5.
+
+	b2 setSuccessor1ForTestingOnly: b3.
+
+	b3 setSuccessor1ForTestingOnly: b4.
+	b3 setSuccessor2ForTestingOnly: b1.
+
+	b5 setSuccessor1ForTestingOnly: b6.
+	b5 setSuccessor2ForTestingOnly: b8.
+
+	b6 setSuccessor1ForTestingOnly: b7.
+
+	b7 setSuccessor1ForTestingOnly: b3.
+
+	b8 setSuccessor1ForTestingOnly: b7.
+
+	cfg entry: b0.
+
+	TRDominanceAnalysis analyze: cfg.
+
+	self assert: b0 immediateDominator equals: nil.
+	self assert: b1 immediateDominator equals: b0.
+	self assert: b2 immediateDominator equals: b1.
+	self assert: b3 immediateDominator equals: b1.
+	self assert: b4 immediateDominator equals: b3.
+	self assert: b5 immediateDominator equals: b1.
+	self assert: b6 immediateDominator equals: b5.
+	self assert: b7 immediateDominator equals: b5.
+	self assert: b8 immediateDominator equals: b5.
+
+	self assert: b0 dominators equals: { b0 } asSet.
+	self assert: b1 dominators equals: { b0 . b1 } asSet.
+	self assert: b2 dominators equals: { b0 . b1 . b2 } asSet.
+	self assert: b3 dominators equals: { b0 . b1 . b3 } asSet.
+	self assert: b4 dominators equals: { b0 . b1 . b3 . b4 } asSet.
+	self assert: b5 dominators equals: { b0 . b1 . b5 } asSet.
+	self assert: b6 dominators equals: { b0 . b1 . b5 . b6 } asSet.
+	self assert: b7 dominators equals: { b0 . b1 . b5 . b7 } asSet.
+	self assert: b8 dominators equals: { b0 . b1 . b5 . b8 } asSet.
+]
+
+{ #category : #tests }
+TRDominanceAnalysisTests >> test_02 [
+	"Taken from Peter Thiemann's 2025 Compiler Construction course [1], [2]
+
+	 [1]: https://proglang.github.io/teaching/25ss/cc/slides/18-loop.pdf
+	 [2]: https://proglang.github.io/teaching/25ss/cc.html
+	"
+
+	| cfg b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 |
+
+	cfg := compilation cfg.
+	b1 := cfg addBlockNamed: 'B1'.
+	b2 := cfg addBlockNamed: 'B2'.
+	b3 := cfg addBlockNamed: 'B3'.
+	b4 := cfg addBlockNamed: 'B4'.
+	b5 := cfg addBlockNamed: 'B5'.
+	b6 := cfg addBlockNamed: 'B6'.
+	b7 := cfg addBlockNamed: 'B7'.
+	b8 := cfg addBlockNamed: 'B8'.
+	b9 := cfg addBlockNamed: 'B9'.
+	b10:= cfg addBlockNamed: 'B10'.
+	b11:= cfg addBlockNamed: 'B11'.
+	b12:= cfg addBlockNamed: 'B12'.
+
+	b1 setSuccessor1ForTestingOnly: b2.
+
+	b2 setSuccessor1ForTestingOnly: b3.
+	b2 setSuccessor2ForTestingOnly: b4.
+
+	b3 setSuccessor1ForTestingOnly: b2.
+
+	b4 setSuccessor1ForTestingOnly: b5.
+	b4 setSuccessor2ForTestingOnly: b6.
+
+	b5 setSuccessor1ForTestingOnly: b8.
+	b5 setSuccessor2ForTestingOnly: b7.
+
+	b6 setSuccessor1ForTestingOnly: b7.
+
+	b7 setSuccessor1ForTestingOnly: b11.
+
+	b8 setSuccessor1ForTestingOnly: b9.
+
+	b9 setSuccessor1ForTestingOnly: b8.
+	b9 setSuccessor2ForTestingOnly: b10.
+
+	b10 setSuccessor1ForTestingOnly: b12.
+	b10 setSuccessor2ForTestingOnly: b5.
+
+	b11 setSuccessor1ForTestingOnly: b12.
+	b11 setSuccessor2ForTestingOnly: b12.
+
+	cfg entry: b1.
+
+	TRDominanceAnalysis analyze: cfg.
+
+	self assert: b1 immediateDominator equals: nil.
+	self assert: b2 immediateDominator equals: b1.
+	self assert: b3 immediateDominator equals: b2.
+	self assert: b4 immediateDominator equals: b2.
+	self assert: b5 immediateDominator equals: b4.
+	self assert: b6 immediateDominator equals: b4.
+	self assert: b7 immediateDominator equals: b4.
+	self assert: b8 immediateDominator equals: b5.
+	self assert: b9 immediateDominator equals: b8.
+	self assert: b10 immediateDominator equals: b9.
+	self assert: b11 immediateDominator equals: b7.
+	self assert: b12 immediateDominator equals: b4.
+]

--- a/src/Tinyrossa-Tests/TRILBlock.extension.st
+++ b/src/Tinyrossa-Tests/TRILBlock.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #TRILBlock }
+
+{ #category : #'*Tinyrossa-Tests' }
+TRILBlock >> setSuccessor1ForTestingOnly: blockOrNil [
+	successor1 notNil ifTrue: [
+		successor1 removePrecedessor: self.
+	].
+	successor1 := blockOrNil.
+	successor1 notNil ifTrue: [
+		successor1 addPrecedessor: self.
+	]
+]
+
+{ #category : #'*Tinyrossa-Tests' }
+TRILBlock >> setSuccessor2ForTestingOnly: block [
+	successor2 notNil ifTrue: [
+		successor2 removePrecedessor: self.
+	].
+	successor2 := block.
+	successor2 notNil ifTrue: [
+		successor2 addPrecedessor: self.
+	]
+]

--- a/src/Tinyrossa/TRDominanceAnalysis.class.st
+++ b/src/Tinyrossa/TRDominanceAnalysis.class.st
@@ -1,0 +1,91 @@
+Class {
+	#name : #TRDominanceAnalysis,
+	#superclass : #Object,
+	#category : #'Tinyrossa-Optimizer-Loops'
+}
+
+{ #category : #analyzing }
+TRDominanceAnalysis class >> analyze: aTRCFG [
+	^ self new analyze: aTRCFG
+]
+
+{ #category : #analyzing }
+TRDominanceAnalysis >> analyze: aTRCFG [
+	"Compute dominator tree. Once finished, in immediate dominator
+	 is stored in each (reachable) block (see #immediateDominator)."
+
+	| blocks dominance initial |
+
+	blocks := aTRCFG blocks.
+	dominance := Dictionary new.
+
+	"Initialize dominance sets for each block"
+	initial := blocks asSet.
+	blocks do: [:block | dominance at: block put: initial ].
+	dominance at: aTRCFG entry put: (Set with: aTRCFG entry).
+
+	"Compute dominance sets. This uses iterative fixpoint algorithm (see
+	 for example [1], Section 9.2.1).
+
+	 [1] Keith D. Cooper, Linda Torczon: Engineering a Compiler Second Edition"
+	[
+		| changed |
+
+		changed := false.
+		blocks do: [:block |
+			| temp |
+
+			temp := Set new
+						add: block;
+						addAll: (self intersectionOfAll: (block precedessors collect:[:pred | dominance at: pred]));
+						yourself.
+
+			temp ~= (dominance at: block) ifTrue: [
+				dominance at: block put: temp.
+				changed := true.
+			].
+		].
+		changed.
+	] whileTrue.
+
+	"Now for each block compute immediate dominator:
+
+		Given a node n in a flow graph, the set of nodes that
+		strictly dominate n is given by (Dom(n) − n). The node
+		in that set that is closest to n is called n’s immediate
+		dominator, denoted IDom(n).
+
+	To easily find the 'closest' node without traversing the CFG,
+	we exploit the fast that blocks are ordered in pre-order manner,
+	meaning parent first and then children, starting with entry block.
+
+	So the 'closest' block to a given block at given index is the
+	one with highest index smaller then given block's index.
+
+	Here we do it reverse so we can conveniently use existing method
+	#indexOfAnyOf:startingAt:ifAbsent:.
+	"
+	blocks := blocks reversed.
+	self assert: blocks last == aTRCFG entry.
+	blocks withIndexDo: [ :block :blockIndex |
+		| idomIndex |
+
+		idomIndex := blocks indexOfAnyOf: (dominance at: block) startingAt: blockIndex + 1 ifAbsent: 0.
+		idomIndex ~= 0 ifTrue: [
+			block setSetImmediateDominator: (blocks at: idomIndex)
+		].
+	].
+]
+
+{ #category : #private }
+TRDominanceAnalysis >> intersectionOfAll: arrayOfSets [
+	| intersection |
+
+	arrayOfSets isEmpty ifTrue:[ ^ Set new ].
+
+	intersection := arrayOfSets first.
+	2 to: arrayOfSets size do: [:i |
+		intersection := intersection intersect: (arrayOfSets at: i).
+	].
+	^ intersection
+]

--- a/src/Tinyrossa/TRILBlock.class.st
+++ b/src/Tinyrossa/TRILBlock.class.st
@@ -35,7 +35,8 @@ Class {
 		'successor2',
 		'next',
 		'startState',
-		'currentState'
+		'currentState',
+		'immediateDominator'
 	],
 	#pools : [
 		'TRILOpcodes'
@@ -105,6 +106,37 @@ TRILBlock >> currentState [
 	^ currentState
 ]
 
+{ #category : #accessing }
+TRILBlock >> dominators [
+	"Return a set of blocks that dominates this block
+	 (the receiver)."
+
+	| dominators |
+
+	dominators := Set new.
+	self dominatorsDo: [ :dominator | dominators add: dominator ].
+	^ dominators
+]
+
+{ #category : #enumerating }
+TRILBlock >> dominatorsDo: aBlock [
+	"Evaluate aBlock for each block that dominates this
+	 block (the receiver)."
+
+	| dominator |
+
+	dominator := self.
+	[ dominator notNil ] whileTrue: [
+		aBlock value: dominator.
+		dominator := dominator immediateDominator.
+	].
+]
+
+{ #category : #accessing }
+TRILBlock >> immediateDominator [
+	^ immediateDominator
+]
+
 { #category : #initialization }
 TRILBlock >> initializeWithCFG: aTRCFG name: aString [
 	self assert: aTRCFG notNil.
@@ -128,6 +160,15 @@ TRILBlock >> isBranching [
 
 	branching := treetops contains: [:node | node opcode isBranching ].
 	^ branching
+]
+
+{ #category : #queries }
+TRILBlock >> isDominatedBy: block [
+	"Resturn true, if this block (receiver) is dominated by given block,
+	 false otherwise."
+
+	self dominatorsDo: [ :dominator | dominator == block ifTrue: [ ^ true ] ].
+	^ false
 ]
 
 { #category : #testing }
@@ -266,6 +307,14 @@ TRILBlock >> setNext: aTRILBlock [
 
 	self assert: (self isTerminated or: [ successor1 == aTRILBlock ]).    
 	next := aTRILBlock.
+]
+
+{ #category : #initialization }
+TRILBlock >> setSetImmediateDominator: block [
+	self assert: block isTRILBlock.
+	self assert: immediateDominator isNil.
+
+	immediateDominator := block
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
This commit adds dominance analysis that computes dominators for each (reachable) block in CFG based on standard iterative fixpoint algorithm. Once computed, dominators are encoded as reverse dominator tree using immediateDominator link stored in each block.